### PR TITLE
Encrypt values of key/value backups with multiple segments if needed 

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/crypto/CipherFactory.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/crypto/CipherFactory.kt
@@ -6,7 +6,7 @@ import javax.crypto.Cipher.ENCRYPT_MODE
 import javax.crypto.spec.GCMParameterSpec
 
 private const val CIPHER_TRANSFORMATION = "AES/GCM/NoPadding"
-private const val GCM_AUTHENTICATION_TAG_LENGTH = 128
+internal const val GCM_AUTHENTICATION_TAG_LENGTH = 128
 
 interface CipherFactory {
     fun createEncryptionCipher(): Cipher

--- a/app/src/main/java/com/stevesoltys/seedvault/crypto/Crypto.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/crypto/Crypto.kt
@@ -87,7 +87,9 @@ class CryptoImpl(
     override fun encryptSegment(outputStream: OutputStream, cleartext: ByteArray) {
         val cipher = cipherFactory.createEncryptionCipher()
 
-        check(cipher.getOutputSize(cleartext.size) <= MAX_SEGMENT_LENGTH)
+        check(cipher.getOutputSize(cleartext.size) <= MAX_SEGMENT_LENGTH) {
+            "Cipher's output size ${cipher.getOutputSize(cleartext.size)} is larger than maximum segment length ($MAX_SEGMENT_LENGTH)"
+        }
 
         val encrypted = cipher.doFinal(cleartext)
         val segmentHeader = SegmentHeader(encrypted.size.toShort(), cipher.iv)

--- a/app/src/main/java/com/stevesoltys/seedvault/crypto/Crypto.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/crypto/Crypto.kt
@@ -5,6 +5,8 @@ import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import javax.crypto.Cipher
+import kotlin.math.min
 
 /**
  * A backup stream starts with a version byte followed by an encrypted [VersionHeader].
@@ -51,6 +53,14 @@ interface Crypto {
     fun encryptSegment(outputStream: OutputStream, cleartext: ByteArray)
 
     /**
+     * Like [encryptSegment],
+     * but if the given cleartext [ByteArray] is larger than [MAX_SEGMENT_CLEARTEXT_LENGTH],
+     * multiple segments will be written.
+     */
+    @Throws(IOException::class)
+    fun encryptMultipleSegments(outputStream: OutputStream, cleartext: ByteArray)
+
+    /**
      * Reads and decrypts a [VersionHeader] from the given [InputStream]
      * and ensures that the expected version, package name and key match
      * what is found in the header.
@@ -69,6 +79,12 @@ interface Crypto {
      */
     @Throws(EOFException::class, IOException::class, SecurityException::class)
     fun decryptSegment(inputStream: InputStream): ByteArray
+
+    /**
+     * Like [decryptSegment], but decrypts multiple segments and does not throw [EOFException].
+     */
+    @Throws(IOException::class, SecurityException::class)
+    fun decryptMultipleSegments(inputStream: InputStream): ByteArray
 }
 
 class CryptoImpl(
@@ -90,8 +106,24 @@ class CryptoImpl(
         check(cipher.getOutputSize(cleartext.size) <= MAX_SEGMENT_LENGTH) {
             "Cipher's output size ${cipher.getOutputSize(cleartext.size)} is larger than maximum segment length ($MAX_SEGMENT_LENGTH)"
         }
+        encryptSegment(cipher, outputStream, cleartext)
+    }
 
-        val encrypted = cipher.doFinal(cleartext)
+    @Throws(IOException::class)
+    override fun encryptMultipleSegments(outputStream: OutputStream, cleartext: ByteArray) {
+        var end = 0
+        while (end < cleartext.size) {
+            val start = end
+            end = min(cleartext.size, start + MAX_SEGMENT_CLEARTEXT_LENGTH)
+            val segment = cleartext.copyOfRange(start, end)
+            val cipher = cipherFactory.createEncryptionCipher()
+            encryptSegment(cipher, outputStream, segment)
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun encryptSegment(cipher: Cipher, outputStream: OutputStream, segment: ByteArray) {
+        val encrypted = cipher.doFinal(segment)
         val segmentHeader = SegmentHeader(encrypted.size.toShort(), cipher.iv)
         headerWriter.writeSegmentHeader(outputStream, segmentHeader)
         outputStream.write(encrypted)
@@ -121,8 +153,21 @@ class CryptoImpl(
         return decryptSegment(inputStream, MAX_SEGMENT_LENGTH)
     }
 
+    @Throws(IOException::class, SecurityException::class)
+    override fun decryptMultipleSegments(inputStream: InputStream): ByteArray {
+        var result = ByteArray(0)
+        while (true) {
+            try {
+                result += decryptSegment(inputStream, MAX_SEGMENT_LENGTH)
+            } catch (e: EOFException) {
+                if (result.isEmpty()) throw IOException(e)
+                return result
+            }
+        }
+    }
+
     @Throws(EOFException::class, IOException::class, SecurityException::class)
-    fun decryptSegment(inputStream: InputStream, maxSegmentLength: Int): ByteArray {
+    private fun decryptSegment(inputStream: InputStream, maxSegmentLength: Int): ByteArray {
         val segmentHeader = headerReader.readSegmentHeader(inputStream)
         if (segmentHeader.segmentLength > maxSegmentLength) {
             throw SecurityException("Segment length too long: ${segmentHeader.segmentLength} > $maxSegmentLength")

--- a/app/src/main/java/com/stevesoltys/seedvault/header/Header.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/header/Header.kt
@@ -15,8 +15,12 @@ data class VersionHeader(
         internal val key: String? = null      // ?? bytes
 ) {
     init {
-        check(packageName.length <= MAX_PACKAGE_LENGTH_SIZE)
-        key?.let { check(key.length <= MAX_KEY_LENGTH_SIZE) }
+        check(packageName.length <= MAX_PACKAGE_LENGTH_SIZE) {
+            "Package $packageName has name longer than $MAX_PACKAGE_LENGTH_SIZE"
+        }
+        key?.let {
+            check(key.length <= MAX_KEY_LENGTH_SIZE) { "Key $key is longer than $MAX_KEY_LENGTH_SIZE" }
+        }
     }
 }
 
@@ -34,6 +38,8 @@ class SegmentHeader(
         internal val nonce: ByteArray         // 12 bytes
 ) {
     init {
-        check(nonce.size == IV_SIZE)
+        check(nonce.size == IV_SIZE) {
+            "Nonce size of ${nonce.size} is not the expected IV size of $IV_SIZE"
+        }
     }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/header/Header.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/header/Header.kt
@@ -1,5 +1,7 @@
 package com.stevesoltys.seedvault.header
 
+import com.stevesoltys.seedvault.crypto.GCM_AUTHENTICATION_TAG_LENGTH
+
 internal const val VERSION: Byte = 0
 internal const val MAX_PACKAGE_LENGTH_SIZE = 255
 internal const val MAX_KEY_LENGTH_SIZE = MAX_PACKAGE_LENGTH_SIZE
@@ -27,6 +29,7 @@ data class VersionHeader(
 
 internal const val SEGMENT_LENGTH_SIZE: Int = Short.SIZE_BYTES
 internal const val MAX_SEGMENT_LENGTH: Int = Short.MAX_VALUE.toInt()
+internal const val MAX_SEGMENT_CLEARTEXT_LENGTH: Int = MAX_SEGMENT_LENGTH - GCM_AUTHENTICATION_TAG_LENGTH / 8
 internal const val IV_SIZE: Int = 12
 internal const val SEGMENT_HEADER_SIZE = SEGMENT_LENGTH_SIZE + IV_SIZE
 

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataReader.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataReader.kt
@@ -26,7 +26,7 @@ class MetadataReaderImpl(private val crypto: Crypto) : MetadataReader {
         if (version < 0) throw IOException()
         if (version > VERSION) throw UnsupportedVersionException(version)
         val metadataBytes = try {
-            crypto.decryptSegment(inputStream)
+            crypto.decryptMultipleSegments(inputStream)
         } catch (e: AEADBadTagException) {
             throw DecryptionFailedException(e)
         }

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataWriter.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataWriter.kt
@@ -20,7 +20,7 @@ class MetadataWriterImpl(private val crypto: Crypto): MetadataWriter {
     override fun write(outputStream: OutputStream, token: Long) {
         val metadata = BackupMetadata(token = token)
         outputStream.write(ByteArray(1).apply { this[0] = metadata.version })
-        crypto.encryptSegment(outputStream, encode(metadata))
+        crypto.encryptMultipleSegments(outputStream, encode(metadata))
     }
 
     @VisibleForTesting

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreViewModel.kt
@@ -62,7 +62,7 @@ class RestoreViewModel(app: Application) : RequireProvisioningViewModel(app), Re
 
     override fun onRestoreSetClicked(set: RestoreSet) {
         val session = this.session
-        check(session != null)
+        check(session != null) { "Restore set clicked, but no session available" }
         session.restoreAll(set.token, observer, monitor)
 
         mChosenRestoreSet.value = set

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsManager.kt
@@ -35,7 +35,7 @@ class SettingsManager(context: Context) {
     fun getStorage(): Storage? {
         val uriStr = prefs.getString(PREF_KEY_STORAGE_URI, null) ?: return null
         val uri = Uri.parse(uriStr)
-        val name = prefs.getString(PREF_KEY_STORAGE_NAME, null) ?: throw IllegalStateException()
+        val name = prefs.getString(PREF_KEY_STORAGE_NAME, null) ?: throw IllegalStateException("no storage name")
         val isUsb = prefs.getBoolean(PREF_KEY_STORAGE_IS_USB, false)
         return Storage(uri, name, isUsb)
     }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransportService.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransportService.kt
@@ -33,7 +33,7 @@ class ConfigurableBackupTransportService : Service() {
     }
 
     override fun onBind(intent: Intent): IBinder {
-        val transport = this.transport ?: throw IllegalStateException()
+        val transport = this.transport ?: throw IllegalStateException("no transport in onBind()")
         return transport.binder.apply {
             Log.d(TAG, "Transport bound.")
         }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupCoordinator.kt
@@ -178,11 +178,11 @@ class BackupCoordinator(
 
     fun finishBackup(): Int = when {
         kv.hasState() -> {
-            check(!full.hasState())
+            check(!full.hasState()) { "K/V backup has state, but full backup has dangling state as well" }
             kv.finishBackup()
         }
         full.hasState() -> {
-            check(!kv.hasState())
+            check(!kv.hasState()) { "Full backup has state, but K/V backup has dangling state as well" }
             full.finishBackup()
         }
         calledInitialize || calledClearBackupData -> {
@@ -190,7 +190,7 @@ class BackupCoordinator(
             calledClearBackupData = false
             TRANSPORT_OK
         }
-        else -> throw IllegalStateException()
+        else -> throw IllegalStateException("Unexpected state in finishBackup()")
     }
 
     @Throws(IOException::class)

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackup.kt
@@ -102,7 +102,7 @@ class KVBackup(
                     val header = VersionHeader(packageName = packageInfo.packageName, key = op.key)
                     headerWriter.writeVersion(outputStream, header)
                     crypto.encryptHeader(outputStream, header)
-                    crypto.encryptSegment(outputStream, op.value)
+                    crypto.encryptMultipleSegments(outputStream, op.value)
                     outputStream.flush()
                     closeQuietly(outputStream)
                 }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/FullRestore.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/FullRestore.kt
@@ -77,7 +77,7 @@ internal class FullRestore(
      */
     fun getNextFullRestoreDataChunk(socket: ParcelFileDescriptor): Int {
         Log.i(TAG, "Get next full restore data chunk.")
-        val state = this.state ?: throw IllegalStateException()
+        val state = this.state ?: throw IllegalStateException("no state")
         val packageName = state.packageInfo.packageName
 
         if (state.inputStream == null) {
@@ -103,9 +103,9 @@ internal class FullRestore(
     }
 
     private fun readInputStream(socket: ParcelFileDescriptor): Int = socket.use { fileDescriptor ->
-        val state = this.state ?: throw IllegalStateException()
+        val state = this.state ?: throw IllegalStateException("no state")
         val packageName = state.packageInfo.packageName
-        val inputStream = state.inputStream ?: throw IllegalStateException()
+        val inputStream = state.inputStream ?: throw IllegalStateException("no stream")
         val outputStream = outputFactory.getOutputStream(fileDescriptor)
 
         try {
@@ -144,7 +144,7 @@ internal class FullRestore(
      * with no further attempts to restore app data.
      */
     fun abortFullRestore(): Int {
-        val state = this.state ?: throw IllegalStateException()
+        val state = this.state ?: throw IllegalStateException("no state")
         Log.i(TAG, "Abort full restore of ${state.packageInfo.packageName}!")
 
         resetState()
@@ -156,7 +156,7 @@ internal class FullRestore(
      * freeing any resources and connections used during the restore process.
      */
     fun finishRestore() {
-        val state = this.state ?: throw IllegalStateException()
+        val state = this.state ?: throw IllegalStateException("no state")
         Log.i(TAG, "Finish restore of ${state.packageInfo.packageName}!")
 
         resetState()

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestore.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestore.kt
@@ -124,7 +124,7 @@ internal class KVRestore(
         try {
             val version = headerReader.readVersion(inputStream)
             crypto.decryptHeader(inputStream, version, state.packageInfo.packageName, dKey.key)
-            val value = crypto.decryptSegment(inputStream)
+            val value = crypto.decryptMultipleSegments(inputStream)
             val size = value.size
             Log.v(TAG, "    ... key=${dKey.key} size=$size")
 

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestore.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestore.kt
@@ -55,7 +55,7 @@ internal class KVRestore(
      * or [TRANSPORT_ERROR] (an error occurred, the restore should be aborted and rescheduled).
      */
     fun getRestoreData(data: ParcelFileDescriptor): Int {
-        val state = this.state ?: throw IllegalStateException()
+        val state = this.state ?: throw IllegalStateException("no state")
 
         // The restore set is the concatenation of the individual record blobs,
         // each of which is a file in the package's directory.

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/StorageViewModel.kt
@@ -87,7 +87,7 @@ internal abstract class StorageViewModel(private val app: Application) : Android
      */
     protected fun saveStorage(uri: Uri): Boolean {
         // store backup storage location in settings
-        val root = storageRoot ?: throw IllegalStateException()
+        val root = storageRoot ?: throw IllegalStateException("no storage root")
         val name = if (root.isInternal()) {
             "${root.title} (${app.getString(R.string.settings_backup_location_internal)})"
         } else {

--- a/app/src/test/java/com/stevesoltys/seedvault/crypto/CryptoImplTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/crypto/CryptoImplTest.kt
@@ -7,11 +7,13 @@ import com.stevesoltys.seedvault.header.MAX_SEGMENT_LENGTH
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 import javax.crypto.Cipher
 import kotlin.random.Random
 
@@ -48,6 +50,14 @@ class CryptoImplTest {
         every { cipher.doFinal(ciphertext) } returns cleartext
 
         assertArrayEquals(cleartext, crypto.decryptSegment(inputStream))
+    }
+
+    @Test
+    fun `decrypting multiple segments on empty stream throws`() {
+        val inputStream = ByteArrayInputStream(ByteArray(0))
+        assertThrows(IOException::class.java) {
+            crypto.decryptMultipleSegments(inputStream)
+        }
     }
 
 }

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/backup/KVBackupTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/backup/KVBackupTest.kt
@@ -142,7 +142,7 @@ internal class KVBackupTest : BackupTest() {
         writeHeaderAndEncrypt()
         every { plugin.getOutputStreamForRecord(packageInfo, key64) } returns outputStream
         every { headerWriter.writeVersion(outputStream, versionHeader) } just Runs
-        every { crypto.encryptSegment(outputStream, any()) } throws IOException()
+        every { crypto.encryptMultipleSegments(outputStream, any()) } throws IOException()
 
         assertEquals(TRANSPORT_ERROR, backup.performBackup(packageInfo, data, 0))
         assertFalse(backup.hasState())
@@ -205,7 +205,7 @@ internal class KVBackupTest : BackupTest() {
         every { plugin.getOutputStreamForRecord(packageInfo, key64) } returns outputStream
         every { headerWriter.writeVersion(outputStream, versionHeader) } just Runs
         every { crypto.encryptHeader(outputStream, versionHeader) } just Runs
-        every { crypto.encryptSegment(outputStream, any()) } just Runs
+        every { crypto.encryptMultipleSegments(outputStream, any()) } just Runs
     }
 
 }

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/restore/KVRestoreTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/restore/KVRestoreTest.kt
@@ -88,7 +88,7 @@ internal class KVRestoreTest : RestoreTest() {
         every { plugin.getInputStreamForRecord(token, packageInfo, key64) } returns inputStream
         every { headerReader.readVersion(inputStream) } returns VERSION
         every { crypto.decryptHeader(inputStream, VERSION, packageInfo.packageName, key) } returns versionHeader
-        every { crypto.decryptSegment(inputStream) } throws IOException()
+        every { crypto.decryptMultipleSegments(inputStream) } throws IOException()
         streamsGetClosed()
 
         assertEquals(TRANSPORT_ERROR, restore.getRestoreData(fileDescriptor))
@@ -131,7 +131,7 @@ internal class KVRestoreTest : RestoreTest() {
         every { plugin.getInputStreamForRecord(token, packageInfo, key64) } returns inputStream
         every { headerReader.readVersion(inputStream) } returns VERSION
         every { crypto.decryptHeader(inputStream, VERSION, packageInfo.packageName, key) } returns versionHeader
-        every { crypto.decryptSegment(inputStream) } returns data
+        every { crypto.decryptMultipleSegments(inputStream) } returns data
         every { output.writeEntityHeader(key, data.size) } throws IOException()
         streamsGetClosed()
 
@@ -147,7 +147,7 @@ internal class KVRestoreTest : RestoreTest() {
         every { plugin.getInputStreamForRecord(token, packageInfo, key64) } returns inputStream
         every { headerReader.readVersion(inputStream) } returns VERSION
         every { crypto.decryptHeader(inputStream, VERSION, packageInfo.packageName, key) } returns versionHeader
-        every { crypto.decryptSegment(inputStream) } returns data
+        every { crypto.decryptMultipleSegments(inputStream) } returns data
         every { output.writeEntityHeader(key, data.size) } returns 42
         every { output.writeEntityData(data, data.size) } throws IOException()
         streamsGetClosed()
@@ -164,7 +164,7 @@ internal class KVRestoreTest : RestoreTest() {
         every { plugin.getInputStreamForRecord(token, packageInfo, key64) } returns inputStream
         every { headerReader.readVersion(inputStream) } returns VERSION
         every { crypto.decryptHeader(inputStream, VERSION, packageInfo.packageName, key) } returns versionHeader
-        every { crypto.decryptSegment(inputStream) } returns data
+        every { crypto.decryptMultipleSegments(inputStream) } returns data
         every { output.writeEntityHeader(key, data.size) } returns 42
         every { output.writeEntityData(data, data.size) } returns data.size
         streamsGetClosed()
@@ -184,14 +184,14 @@ internal class KVRestoreTest : RestoreTest() {
         every { plugin.getInputStreamForRecord(token, packageInfo, key64) } returns inputStream
         every { headerReader.readVersion(inputStream) } returns VERSION
         every { crypto.decryptHeader(inputStream, VERSION, packageInfo.packageName, key) } returns versionHeader
-        every { crypto.decryptSegment(inputStream) } returns data
+        every { crypto.decryptMultipleSegments(inputStream) } returns data
         every { output.writeEntityHeader(key, data.size) } returns 42
         every { output.writeEntityData(data, data.size) } returns data.size
         // second key/value
         every { plugin.getInputStreamForRecord(token, packageInfo, key264) } returns inputStream2
         every { headerReader.readVersion(inputStream2) } returns VERSION
         every { crypto.decryptHeader(inputStream2, VERSION, packageInfo.packageName, key2) } returns versionHeader2
-        every { crypto.decryptSegment(inputStream2) } returns data2
+        every { crypto.decryptMultipleSegments(inputStream2) } returns data2
         every { output.writeEntityHeader(key2, data2.size) } returns 42
         every { output.writeEntityData(data2, data2.size) } returns data2.size
         every { inputStream2.close() } just Runs


### PR DESCRIPTION
This turned out to be necessary, because some values on production
devices are exceeding the maximum segment size.

The MR also adds messages for illegal states to help us debugging those faster in the future.