### PR TITLE
Remove wrongly inserted "g" char from AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
     <uses-permission
         android:name="android.permission.MANAGE_USB"
         tools:ignore="ProtectedPermissions" />
-g
+
     <!-- This is needed to change system backup settings -->
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"


### PR DESCRIPTION
It was not caught by CI tests because it is still valid XML. Not even `gradle check` complained.

Introduced in: 78e217c7d8b4d0508b243a81b20417f7d9b9250e