### PR TITLE
Clean up backup transport initialization logic

### DIFF
--- a/.idea/runConfigurations/Instrumentation_Tests.xml
+++ b/.idea/runConfigurations/Instrumentation_Tests.xml
@@ -1,0 +1,48 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Instrumentation Tests" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests">
+    <module name="app" />
+    <option name="TESTING_TYPE" value="0" />
+    <option name="METHOD_NAME" value="" />
+    <option name="CLASS_NAME" value="" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />
+    <option name="EXTRA_OPTIONS" value="-e notAnnotation androidx.test.filters.LargeTest" />
+    <option name="INCLUDE_GRADLE_EXTRA_OPTIONS" value="true" />
+    <option name="CLEAR_LOGCAT" value="false" />
+    <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
+    <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
+    <option name="FORCE_STOP_RUNNING_APP" value="true" />
+    <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
+    <option name="DEBUGGER_TYPE" value="Auto" />
+    <Auto>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+    </Auto>
+    <Hybrid>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+    </Hybrid>
+    <Java />
+    <Native>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+    </Native>
+    <Profilers>
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_CONFIGURATION_NAME" value="Sample Java Methods" />
+    </Profilers>
+    <method v="2">
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/app/src/androidTest/java/com/stevesoltys/seedvault/CipherUniqueNonceTest.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/CipherUniqueNonceTest.kt
@@ -1,8 +1,8 @@
 package com.stevesoltys.seedvault
 
 import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.runner.AndroidJUnit4
 import com.stevesoltys.seedvault.crypto.CipherFactoryImpl
 import com.stevesoltys.seedvault.crypto.KeyManagerTestImpl
 import org.junit.Assert.assertTrue

--- a/app/src/androidTest/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorageTest.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorageTest.kt
@@ -45,7 +45,7 @@ class DocumentsStorageTest : KoinComponent {
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val metadataManager by inject<MetadataManager>()
     private val settingsManager by inject<SettingsManager>()
-    private val storage = DocumentsStorage(context, metadataManager, settingsManager)
+    private val storage = DocumentsStorage(context, settingsManager)
 
     private val filename = getRandomBase64()
     private lateinit var file: DocumentFile
@@ -96,6 +96,7 @@ class DocumentsStorageTest : KoinComponent {
         val foundFile = storage.rootBackupDir!!.findFileBlocking(context, file.name!!)
         assertNotNull(foundFile)
         assertEquals(filename, foundFile!!.name)
+        assertEquals(storage.rootBackupDir!!.uri, foundFile.parentFile?.uri)
     }
 
     @Test

--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.ServiceManager.getService
 import com.stevesoltys.seedvault.crypto.cryptoModule
 import com.stevesoltys.seedvault.header.headerModule
+import com.stevesoltys.seedvault.metadata.MetadataManager
 import com.stevesoltys.seedvault.metadata.metadataModule
 import com.stevesoltys.seedvault.plugins.saf.documentsProviderModule
 import com.stevesoltys.seedvault.restore.RestoreViewModel
@@ -19,6 +20,7 @@ import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import com.stevesoltys.seedvault.ui.recoverycode.RecoveryCodeViewModel
 import com.stevesoltys.seedvault.ui.storage.BackupStorageViewModel
 import com.stevesoltys.seedvault.ui.storage.RestoreStorageViewModel
+import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -39,7 +41,7 @@ class App : Application() {
 
         viewModel { SettingsViewModel(this@App, get(), get(), get(), get()) }
         viewModel { RecoveryCodeViewModel(this@App, get()) }
-        viewModel { BackupStorageViewModel(this@App, get(), get()) }
+        viewModel { BackupStorageViewModel(this@App, get(), get(), get()) }
         viewModel { RestoreStorageViewModel(this@App, get(), get()) }
         viewModel { RestoreViewModel(this@App, get(), get(), get(), get(), get()) }
     }
@@ -49,7 +51,8 @@ class App : Application() {
         startKoin {
             androidLogger()
             androidContext(this@App)
-            modules(listOf(
+            modules(
+                listOf(
                     cryptoModule,
                     headerModule,
                     metadataModule,
@@ -57,7 +60,25 @@ class App : Application() {
                     backupModule,
                     restoreModule,
                     appModule
-            ))
+                )
+            )
+        }
+        migrateTokenFromMetadataToSettingsManager()
+    }
+
+    private val settingsManager: SettingsManager by inject()
+    private val metadataManager: MetadataManager by inject()
+
+    /**
+     * The responsibility for the current token was moved to the [SettingsManager]
+     * in the end of 2020.
+     * This method migrates the token for existing installs and can be removed
+     * after sufficient time has passed.
+     */
+    private fun migrateTokenFromMetadataToSettingsManager() {
+        val token = metadataManager.getBackupToken()
+        if (token != 0L && settingsManager.getToken() == null) {
+            settingsManager.setNewToken(token)
         }
     }
 

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataManager.kt
@@ -178,6 +178,7 @@ class MetadataManager(
      * If the token is 0L, it is not yet initialized and must not be used for anything.
      */
     @Synchronized
+    @Deprecated("Responsibility for current token moved to SettingsManager", ReplaceWith("settingsManager.getToken()"))
     fun getBackupToken(): Long = metadata.token
 
     /**

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderFullBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderFullBackup.kt
@@ -12,8 +12,8 @@ private val TAG = DocumentsProviderFullBackup::class.java.simpleName
 
 @Suppress("BlockingMethodInNonBlockingContext")
 internal class DocumentsProviderFullBackup(
-    private val storage: DocumentsStorage,
-    private val context: Context
+    private val context: Context,
+    private val storage: DocumentsStorage
 ) : FullBackupPlugin {
 
     override fun getQuota() = DEFAULT_QUOTA_FULL_BACKUP

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVBackup.kt
@@ -14,8 +14,8 @@ const val MAX_KEY_LENGTH_NEXTCLOUD = 225
 
 @Suppress("BlockingMethodInNonBlockingContext")
 internal class DocumentsProviderKVBackup(
-    private val storage: DocumentsStorage,
-    private val context: Context
+    private val context: Context,
+    private val storage: DocumentsStorage
 ) : KVBackupPlugin {
 
     private var packageFile: DocumentFile? = null
@@ -27,7 +27,7 @@ internal class DocumentsProviderKVBackup(
         val packageFile =
             storage.currentKvBackupDir?.findFileBlocking(context, packageInfo.packageName)
                 ?: return false
-        return packageFile.listFiles().isNotEmpty()
+        return packageFile.listFilesBlocking(context).isNotEmpty()
     }
 
     @Throws(IOException::class)

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVRestorePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVRestorePlugin.kt
@@ -26,10 +26,11 @@ internal class DocumentsProviderKVRestorePlugin(
         }
     }
 
-    override fun listRecords(token: Long, packageInfo: PackageInfo): List<String> {
+    @Throws(IOException::class)
+    override suspend fun listRecords(token: Long, packageInfo: PackageInfo): List<String> {
         val packageDir = this.packageDir ?: throw AssertionError()
         packageDir.assertRightFile(packageInfo)
-        return packageDir.listFiles()
+        return packageDir.listFilesBlocking(context)
             .filter { file -> file.name != null }
             .map { file -> file.name!! }
     }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderModule.kt
@@ -1,12 +1,22 @@
 package com.stevesoltys.seedvault.plugins.saf
 
 import com.stevesoltys.seedvault.transport.backup.BackupPlugin
+import com.stevesoltys.seedvault.transport.backup.FullBackupPlugin
+import com.stevesoltys.seedvault.transport.backup.KVBackupPlugin
+import com.stevesoltys.seedvault.transport.restore.FullRestorePlugin
+import com.stevesoltys.seedvault.transport.restore.KVRestorePlugin
 import com.stevesoltys.seedvault.transport.restore.RestorePlugin
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val documentsProviderModule = module {
-    single { DocumentsStorage(androidContext(), get(), get()) }
-    single<BackupPlugin> { DocumentsProviderBackupPlugin(androidContext(), get()) }
-    single<RestorePlugin> { DocumentsProviderRestorePlugin(androidContext(), get()) }
+    single { DocumentsStorage(androidContext(), get()) }
+
+    single<KVBackupPlugin> { DocumentsProviderKVBackup(androidContext(), get()) }
+    single<FullBackupPlugin> { DocumentsProviderFullBackup(androidContext(), get()) }
+    single<BackupPlugin> { DocumentsProviderBackupPlugin(androidContext(), get(), get(), get()) }
+
+    single<KVRestorePlugin> { DocumentsProviderKVRestorePlugin(androidContext(), get()) }
+    single<FullRestorePlugin> { DocumentsProviderFullRestorePlugin(androidContext(), get()) }
+    single<RestorePlugin> { DocumentsProviderRestorePlugin(androidContext(), get(), get(), get()) }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderRestorePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderRestorePlugin.kt
@@ -19,16 +19,10 @@ private val TAG = DocumentsProviderRestorePlugin::class.java.simpleName
 @Suppress("BlockingMethodInNonBlockingContext") // all methods do I/O
 internal class DocumentsProviderRestorePlugin(
     private val context: Context,
-    private val storage: DocumentsStorage
+    private val storage: DocumentsStorage,
+    override val kvRestorePlugin: KVRestorePlugin,
+    override val fullRestorePlugin: FullRestorePlugin
 ) : RestorePlugin {
-
-    override val kvRestorePlugin: KVRestorePlugin by lazy {
-        DocumentsProviderKVRestorePlugin(context, storage)
-    }
-
-    override val fullRestorePlugin: FullRestorePlugin by lazy {
-        DocumentsProviderFullRestorePlugin(context, storage)
-    }
 
     @Throws(IOException::class)
     override suspend fun hasBackup(uri: Uri): Boolean {

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreViewModel.kt
@@ -166,6 +166,12 @@ internal class RestoreViewModel(
     private suspend fun startRestore(token: Long) {
         Log.d(TAG, "Starting new restore session to restore backup $token")
 
+        // if we had no token before (i.e. restore from setup wizard),
+        // use the token of the current restore set from now on
+        if (settingsManager.getToken() == null) {
+            settingsManager.setNewToken(token)
+        }
+
         // we need to start a new session and retrieve the restore sets before starting the restore
         val restoreSetResult = getAvailableRestoreSets()
         if (restoreSetResult.hasError()) {

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupPlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupPlugin.kt
@@ -1,5 +1,6 @@
 package com.stevesoltys.seedvault.transport.backup
 
+import android.app.backup.RestoreSet
 import android.content.pm.PackageInfo
 import java.io.IOException
 import java.io.OutputStream
@@ -11,13 +12,18 @@ interface BackupPlugin {
     val fullBackupPlugin: FullBackupPlugin
 
     /**
-     * Initialize the storage for this device, erasing all stored data.
+     * Start a new [RestoreSet] with the given token.
      *
-     * @return true if the device needs initialization or
-     * false if the device was initialized already and initialization should be a no-op.
+     * This is typically followed by a call to [initializeDevice].
      */
     @Throws(IOException::class)
-    suspend fun initializeDevice(newToken: Long): Boolean
+    suspend fun startNewRestoreSet(token: Long)
+
+    /**
+     * Initialize the storage for this device, erasing all stored data in the current [RestoreSet].
+     */
+    @Throws(IOException::class)
+    suspend fun initializeDevice()
 
     /**
      * Returns an [OutputStream] for writing backup metadata.

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestore.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestore.kt
@@ -112,7 +112,7 @@ internal class KVRestore(
      * Return a list of the records (represented by key files) in the given directory,
      * sorted lexically by the Base64-decoded key file name, not by the on-disk filename.
      */
-    private fun getSortedKeys(token: Long, packageInfo: PackageInfo): List<DecodedKey>? {
+    private suspend fun getSortedKeys(token: Long, packageInfo: PackageInfo): List<DecodedKey>? {
         val records: List<String> = try {
             plugin.listRecords(token, packageInfo)
         } catch (e: IOException) {

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestorePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestorePlugin.kt
@@ -20,7 +20,7 @@ interface KVRestorePlugin {
      * For file-based plugins, this is usually a list of file names in the package directory.
      */
     @Throws(IOException::class)
-    fun listRecords(token: Long, packageInfo: PackageInfo): List<String>
+    suspend fun listRecords(token: Long, packageInfo: PackageInfo): List<String>
 
     /**
      * Return an [InputStream] for the given token, package and key

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinator.kt
@@ -13,7 +13,6 @@ import android.content.pm.PackageInfo
 import android.os.ParcelFileDescriptor
 import android.util.Log
 import androidx.collection.LongSparseArray
-import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import com.stevesoltys.seedvault.MAGIC_PACKAGE_MANAGER
 import com.stevesoltys.seedvault.R
 import com.stevesoltys.seedvault.header.UnsupportedVersionException
@@ -22,18 +21,19 @@ import com.stevesoltys.seedvault.metadata.DecryptionFailedException
 import com.stevesoltys.seedvault.metadata.MetadataManager
 import com.stevesoltys.seedvault.metadata.MetadataReader
 import com.stevesoltys.seedvault.settings.SettingsManager
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import libcore.io.IoUtils.closeQuietly
 import java.io.IOException
 
 private class RestoreCoordinatorState(
-    internal val token: Long,
-    internal val packages: Iterator<PackageInfo>,
+    val token: Long,
+    val packages: Iterator<PackageInfo>,
     /**
      * Optional [PackageInfo] for single package restore, to reduce data needed to read for @pm@
      */
-    internal val pmPackageInfo: PackageInfo?
+    val pmPackageInfo: PackageInfo?
 ) {
-    internal var currentPackage: String? = null
+    var currentPackage: String? = null
 }
 
 private val TAG = RestoreCoordinator::class.java.simpleName
@@ -106,8 +106,9 @@ internal class RestoreCoordinator(
      * or 0 if there is no backup set available corresponding to the current device state.
      */
     fun getCurrentRestoreSet(): Long {
-        return metadataManager.getBackupToken()
-            .apply { Log.i(TAG, "Got current restore set token: $this") }
+        return (settingsManager.getToken() ?: 0L).apply {
+            Log.i(TAG, "Got current restore set token: $this")
+        }
     }
 
     /**

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/storage/BackupStorageViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/storage/BackupStorageViewModel.kt
@@ -8,36 +8,51 @@ import android.net.Uri
 import android.os.UserHandle
 import android.util.Log
 import androidx.annotation.WorkerThread
+import androidx.lifecycle.viewModelScope
 import com.stevesoltys.seedvault.R
 import com.stevesoltys.seedvault.settings.SettingsManager
 import com.stevesoltys.seedvault.transport.TRANSPORT_ID
+import com.stevesoltys.seedvault.transport.backup.BackupCoordinator
 import com.stevesoltys.seedvault.transport.requestBackup
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.IOException
 
 private val TAG = BackupStorageViewModel::class.java.simpleName
 
 internal class BackupStorageViewModel(
-        private val app: Application,
-        private val backupManager: IBackupManager,
-        settingsManager: SettingsManager) : StorageViewModel(app, settingsManager) {
+    private val app: Application,
+    private val backupManager: IBackupManager,
+    private val backupCoordinator: BackupCoordinator,
+    settingsManager: SettingsManager
+) : StorageViewModel(app, settingsManager) {
 
     override val isRestoreOperation = false
 
     override fun onLocationSet(uri: Uri) {
         val isUsb = saveStorage(uri)
-        settingsManager.forceStorageInitialization()
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                // will also generate a new backup token for the new restore set
+                backupCoordinator.startNewRestoreSet()
 
-        // initialize the new location, will also generate a new backup token
-        val observer = InitializationObserver()
-        backupManager.initializeTransportsForUser(UserHandle.myUserId(), arrayOf(TRANSPORT_ID), observer)
-
-        // if storage is on USB and this is not SetupWizard, do a backup right away
-        if (isUsb && !isSetupWizard) Thread {
-            requestBackup(app)
-        }.start()
+                // initialize the new location
+                backupManager.initializeTransportsForUser(
+                    UserHandle.myUserId(),
+                    arrayOf(TRANSPORT_ID),
+                    // if storage is on USB and this is not SetupWizard, do a backup right away
+                    InitializationObserver(isUsb && !isSetupWizard)
+                )
+            } catch (e: IOException) {
+                Log.e(TAG, "Error starting new RestoreSet", e)
+                onInitializationError()
+            }
+        }
     }
 
     @WorkerThread
-    private inner class InitializationObserver : IBackupObserver.Stub() {
+    private inner class InitializationObserver(val requestBackup: Boolean) :
+        IBackupObserver.Stub() {
         override fun onUpdate(currentBackupPackage: String, backupProgress: BackupProgress) {
             // noop
         }
@@ -53,12 +68,19 @@ internal class BackupStorageViewModel(
             if (status == 0) {
                 // notify the UI that the location has been set
                 mLocationChecked.postEvent(LocationResult())
+                if (requestBackup) {
+                    requestBackup(app)
+                }
             } else {
                 // notify the UI that the location was invalid
-                val errorMsg = app.getString(R.string.storage_check_fragment_backup_error)
-                mLocationChecked.postEvent(LocationResult(errorMsg))
+                onInitializationError()
             }
         }
+    }
+
+    private fun onInitializationError() {
+        val errorMsg = app.getString(R.string.storage_check_fragment_backup_error)
+        mLocationChecked.postEvent(LocationResult(errorMsg))
     }
 
 }

--- a/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/BackupPluginTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/BackupPluginTest.kt
@@ -1,0 +1,65 @@
+package com.stevesoltys.seedvault.plugins.saf
+
+import androidx.documentfile.provider.DocumentFile
+import com.stevesoltys.seedvault.transport.backup.BackupTest
+import com.stevesoltys.seedvault.transport.backup.FullBackupPlugin
+import com.stevesoltys.seedvault.transport.backup.KVBackupPlugin
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+@Suppress("BlockingMethodInNonBlockingContext")
+internal class BackupPluginTest : BackupTest() {
+
+    private val storage = mockk<DocumentsStorage>()
+    private val kvBackupPlugin: KVBackupPlugin = mockk<DocumentsProviderKVBackup>()
+    private val fullBackupPlugin: FullBackupPlugin = mockk<DocumentsProviderFullBackup>()
+
+    private val plugin = DocumentsProviderBackupPlugin(
+        context,
+        storage,
+        kvBackupPlugin,
+        fullBackupPlugin
+    )
+
+    private val setDir: DocumentFile = mockk()
+    private val kvDir: DocumentFile = mockk()
+    private val fullDir: DocumentFile = mockk()
+
+    init {
+        // to mock extension functions on DocumentFile
+        mockkStatic("com.stevesoltys.seedvault.plugins.saf.DocumentsStorageKt")
+    }
+
+    @Test
+    fun `test startNewRestoreSet`() = runBlocking {
+        every { storage.reset(token) } just Runs
+        every { storage getProperty "rootBackupDir" } returns setDir
+
+        plugin.startNewRestoreSet(token)
+    }
+
+    @Test
+    fun `test initializeDevice`() = runBlocking {
+        // get current set dir and for that the current token
+        every { storage getProperty "currentToken" } returns token
+        every { settingsManager.getToken() } returns token
+        coEvery { storage.getSetDir(token) } returns setDir
+        // delete contents of current set dir
+        coEvery { setDir.listFilesBlocking(context) } returns listOf(kvDir)
+        every { kvDir.delete() } returns true
+        // reset storage
+        every { storage.reset(null) } just Runs
+        // create kv and full dir
+        every { storage getProperty "currentKvBackupDir" } returns kvDir
+        every { storage getProperty "currentFullBackupDir" } returns fullDir
+
+        plugin.initializeDevice()
+    }
+
+}

--- a/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/DocumentFileTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/plugins/saf/DocumentFileTest.kt
@@ -1,0 +1,43 @@
+package com.stevesoltys.seedvault.plugins.saf
+
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.documentfile.provider.DocumentFile
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.stopKoin
+
+@RunWith(AndroidJUnit4::class)
+internal class DocumentFileTest {
+
+    private val context: Context = mockk()
+    private val parentUri: Uri = Uri.parse(
+        "content://com.android.externalstorage.documents/tree/" +
+                "primary%3A/document/primary%3A.SeedVaultAndroidBackup"
+    )
+    private val parentFile: DocumentFile = DocumentFile.fromTreeUri(context, parentUri)!!
+    private val uri: Uri = Uri.parse(
+        "content://com.android.externalstorage.documents/tree/" +
+                "primary%3A/document/primary%3A.SeedVaultAndroidBackup%2Ftest"
+    )
+
+    @After
+    fun afterEachTest() {
+        stopKoin()
+    }
+
+    @Test
+    fun `test ugly getTreeDocumentFile reflection hack`() {
+        assertTrue(DocumentsContract.isTreeUri(uri))
+        val file = getTreeDocumentFile(parentFile, context, uri)
+        assertEquals(uri, file.uri)
+        assertEquals(parentFile, file.parentFile)
+    }
+
+}

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
@@ -7,7 +7,6 @@ import android.app.backup.BackupTransport.TRANSPORT_OK
 import android.app.backup.RestoreDescription
 import android.app.backup.RestoreDescription.TYPE_FULL_STREAM
 import android.os.ParcelFileDescriptor
-import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import com.stevesoltys.seedvault.crypto.CipherFactoryImpl
 import com.stevesoltys.seedvault.crypto.CryptoImpl
 import com.stevesoltys.seedvault.crypto.KeyManagerTestImpl
@@ -35,6 +34,7 @@ import com.stevesoltys.seedvault.transport.restore.KVRestorePlugin
 import com.stevesoltys.seedvault.transport.restore.OutputFactory
 import com.stevesoltys.seedvault.transport.restore.RestoreCoordinator
 import com.stevesoltys.seedvault.transport.restore.RestorePlugin
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -186,7 +186,7 @@ internal class CoordinatorIntegrationTest : TransportTest() {
         val backupDataOutput = mockk<BackupDataOutput>()
         val rInputStream = ByteArrayInputStream(bOutputStream.toByteArray())
         val rInputStream2 = ByteArrayInputStream(bOutputStream2.toByteArray())
-        every { kvRestorePlugin.listRecords(token, packageInfo) } returns listOf(key64, key264)
+        coEvery { kvRestorePlugin.listRecords(token, packageInfo) } returns listOf(key64, key264)
         every { outputFactory.getBackupDataOutput(fileDescriptor) } returns backupDataOutput
         coEvery {
             kvRestorePlugin.getInputStreamForRecord(
@@ -255,7 +255,7 @@ internal class CoordinatorIntegrationTest : TransportTest() {
         // restore finds the backed up key and writes the decrypted value
         val backupDataOutput = mockk<BackupDataOutput>()
         val rInputStream = ByteArrayInputStream(bOutputStream.toByteArray())
-        every { kvRestorePlugin.listRecords(token, packageInfo) } returns listOf(key64)
+        coEvery { kvRestorePlugin.listRecords(token, packageInfo) } returns listOf(key64)
         every { outputFactory.getBackupDataOutput(fileDescriptor) } returns backupDataOutput
         coEvery {
             kvRestorePlugin.getInputStreamForRecord(

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/restore/KVRestoreTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/restore/KVRestoreTest.kt
@@ -56,7 +56,7 @@ internal class KVRestoreTest : RestoreTest() {
     fun `listing records throws`() = runBlocking {
         restore.initializeState(token, packageInfo)
 
-        every { plugin.listRecords(token, packageInfo) } throws IOException()
+        coEvery { plugin.listRecords(token, packageInfo) } throws IOException()
 
         assertEquals(TRANSPORT_ERROR, restore.getRestoreData(fileDescriptor))
     }
@@ -208,7 +208,7 @@ internal class KVRestoreTest : RestoreTest() {
     }
 
     private fun getRecordsAndOutput(recordKeys: List<String> = listOf(key64)) {
-        every { plugin.listRecords(token, packageInfo) } returns recordKeys
+        coEvery { plugin.listRecords(token, packageInfo) } returns recordKeys
         every { outputFactory.getBackupDataOutput(fileDescriptor) } returns output
     }
 

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinatorTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinatorTest.kt
@@ -9,7 +9,6 @@ import android.app.backup.RestoreDescription.TYPE_KEY_VALUE
 import android.content.pm.PackageInfo
 import android.os.ParcelFileDescriptor
 import androidx.documentfile.provider.DocumentFile
-import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import com.stevesoltys.seedvault.coAssertThrows
 import com.stevesoltys.seedvault.getRandomString
 import com.stevesoltys.seedvault.metadata.BackupMetadata
@@ -18,6 +17,7 @@ import com.stevesoltys.seedvault.metadata.MetadataReader
 import com.stevesoltys.seedvault.metadata.PackageMetadata
 import com.stevesoltys.seedvault.settings.Storage
 import com.stevesoltys.seedvault.transport.TransportTest
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
@@ -91,7 +91,7 @@ internal class RestoreCoordinatorTest : TransportTest() {
 
     @Test
     fun `getCurrentRestoreSet() delegates to plugin`() {
-        every { metadataManager.getBackupToken() } returns token
+        every { settingsManager.getToken() } returns token
         assertEquals(token, restore.getCurrentRestoreSet())
     }
 


### PR DESCRIPTION
This PR makes creating new RestoreSets explicit.

Initializing a backup transport now actually cleans its data like the AOSP documentation demands. This should be fine as we usually do a fresh backup after a new initialization.

Contrary to before, an initialization does not create new RestoreSets anymore, but works within the existing set (helps with #102 but doesn't fix the underlying issue). For now, only manually choosing a new storage location creates a new RestoreSet.

This PR also paves the way for #100.