### PR TITLE
Enable backup of call logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It uses the same internal APIs as `adb backup` which is deprecated and thus need
 * `android.permission.BACKUP` to back up application data.
 * `android.permission.MANAGE_DOCUMENTS` to retrieve the available storage roots. 
 * `android.permission.MANAGE_USB` to access the serial number of USB mass storage devices.
-* `android.permission.WRITE_SECURE_SETTINGS` to change system backup settings.
+* `android.permission.WRITE_SECURE_SETTINGS` to change system backup settings and enable call log backup.
 * `android.permission.INSTALL_PACKAGES` to re-install apps when restoring from backup.
 
 ## Contributing

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsFragment.kt
@@ -70,6 +70,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             val enabled = newValue as Boolean
             try {
                 backupManager.isBackupEnabled = enabled
+                if (enabled) viewModel.enableCallLogBackup()
                 return@OnPreferenceChangeListener true
             } catch (e: RemoteException) {
                 e.printStackTrace()
@@ -171,6 +172,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         try {
             backup.isChecked = backupManager.isBackupEnabled
             backup.isEnabled = true
+            // enable call log backups for existing installs (added end of 2020)
+            if (backup.isChecked) viewModel.enableCallLogBackup()
         } catch (e: RemoteException) {
             Log.e(TAG, "Error communicating with BackupManager", e)
             backup.isEnabled = false

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.stevesoltys.seedvault.settings
 
 import android.app.Application
 import android.content.pm.PackageManager.NameNotFoundException
+import android.provider.Settings
 import android.util.Log
 import androidx.annotation.UiThread
 import androidx.core.content.ContextCompat.getDrawable
@@ -33,6 +34,8 @@ import com.stevesoltys.seedvault.ui.notification.getAppName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.Locale
+
+private const val USER_FULL_DATA_BACKUP_AWARE = "user_full_data_backup_aware"
 
 private val TAG = SettingsViewModel::class.java.simpleName
 
@@ -119,6 +122,20 @@ internal class SettingsViewModel(
     @UiThread
     fun onAppStatusToggled(status: AppStatus) {
         settingsManager.onAppBackupStatusChanged(status)
+    }
+
+    /**
+     * Ensures that the call log will be included in backups.
+     *
+     * An AOSP code search found that call log backups get disabled if [USER_FULL_DATA_BACKUP_AWARE]
+     * is not set. This method sets this flag, if it is not already set.
+     * No other apps were found to check for this, so this should affect only call log.
+     */
+    fun enableCallLogBackup() {
+        // first check if the flag is already set
+        if (Settings.Secure.getInt(app.contentResolver, USER_FULL_DATA_BACKUP_AWARE, 0) == 0) {
+            Settings.Secure.putInt(app.contentResolver, USER_FULL_DATA_BACKUP_AWARE, 1)
+        }
     }
 
 }


### PR DESCRIPTION
It turned out that call log backup is already in AOSP, but it is disabled by an undocumented flag. This PR sets this flag (for new
and existing installs) to enable call log backup.

Closes #93 