### PR TITLE
Show notification for backup running in the background

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/App.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/App.kt
@@ -37,7 +37,7 @@ class App : Application() {
         single { Clock() }
         factory<IBackupManager> { IBackupManager.Stub.asInterface(getService(BACKUP_SERVICE)) }
 
-        viewModel { SettingsViewModel(this@App, get(), get(), get(), get()) }
+        viewModel { SettingsViewModel(this@App, get(), get(), get(), get(), get()) }
         viewModel { RecoveryCodeViewModel(this@App, get()) }
         viewModel { BackupStorageViewModel(this@App, get(), get()) }
         viewModel { RestoreStorageViewModel(this@App, get(), get()) }

--- a/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/metadata/MetadataManager.kt
@@ -198,6 +198,8 @@ class MetadataManager(
 
     @Synchronized
     fun getPackagesNumBackedUp(): Int {
+        // FIXME we are under-reporting packages here,
+        //  because we have no way to also include upgraded system apps
         return metadata.packageMetadataMap.filter { (_, packageMetadata) ->
             !packageMetadata.system && ( // ignore system apps
                     packageMetadata.state == APK_AND_DATA || // either full success

--- a/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/settings/SettingsViewModel.kt
@@ -3,6 +3,8 @@ package com.stevesoltys.seedvault.settings
 import android.app.Application
 import android.content.pm.PackageManager.NameNotFoundException
 import android.util.Log
+import android.widget.Toast
+import android.widget.Toast.LENGTH_LONG
 import androidx.annotation.UiThread
 import androidx.core.content.ContextCompat.getDrawable
 import androidx.lifecycle.LiveData
@@ -29,6 +31,7 @@ import com.stevesoltys.seedvault.restore.AppRestoreStatus.SUCCEEDED
 import com.stevesoltys.seedvault.transport.backup.PackageService
 import com.stevesoltys.seedvault.transport.requestBackup
 import com.stevesoltys.seedvault.ui.RequireProvisioningViewModel
+import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import com.stevesoltys.seedvault.ui.notification.getAppName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -40,6 +43,7 @@ internal class SettingsViewModel(
     app: Application,
     settingsManager: SettingsManager,
     keyManager: KeyManager,
+    private val notificationManager: BackupNotificationManager,
     private val metadataManager: MetadataManager,
     private val packageService: PackageService
 ) : RequireProvisioningViewModel(app, settingsManager, keyManager) {
@@ -65,7 +69,11 @@ internal class SettingsViewModel(
     }
 
     internal fun backupNow() {
-        Thread { requestBackup(app) }.start()
+        if (notificationManager.hasActiveBackupNotifications()) {
+            Toast.makeText(app, R.string.notification_backup_already_running, LENGTH_LONG).show()
+        } else {
+            Thread { requestBackup(app) }.start()
+        }
     }
 
     private fun getAppStatusResult(): LiveData<AppStatusResult> = liveData {

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransportService.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/ConfigurableBackupTransportService.kt
@@ -13,10 +13,12 @@ import android.os.RemoteException
 import android.util.Log
 import androidx.annotation.WorkerThread
 import com.stevesoltys.seedvault.BackupMonitor
+import com.stevesoltys.seedvault.transport.backup.PackageService
 import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import com.stevesoltys.seedvault.ui.notification.NotificationBackupObserver
-import com.stevesoltys.seedvault.transport.backup.PackageService
+import org.koin.core.KoinComponent
 import org.koin.core.context.GlobalContext.get
+import org.koin.core.inject
 
 private val TAG = ConfigurableBackupTransportService::class.java.simpleName
 
@@ -24,9 +26,11 @@ private val TAG = ConfigurableBackupTransportService::class.java.simpleName
  * @author Steve Soltys
  * @author Torsten Grote
  */
-class ConfigurableBackupTransportService : Service() {
+class ConfigurableBackupTransportService : Service(), KoinComponent {
 
     private var transport: ConfigurableBackupTransport? = null
+
+    private val notificationManager: BackupNotificationManager by inject()
 
     override fun onCreate() {
         super.onCreate()
@@ -43,6 +47,7 @@ class ConfigurableBackupTransportService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
+        notificationManager.onBackupBackgroundFinished()
         transport = null
         Log.d(TAG, "Service destroyed.")
     }
@@ -55,7 +60,7 @@ fun requestBackup(context: Context) {
     val packages = packageService.eligiblePackages
     val appTotals = packageService.expectedAppTotals
 
-    val observer = NotificationBackupObserver(context, packages.size, appTotals, true)
+    val observer = NotificationBackupObserver(context, packages.size, appTotals)
     val result = try {
         val backupManager: IBackupManager = get().koin.get()
         backupManager.requestBackup(packages, observer, BackupMonitor(), FLAG_USER_INITIATED)

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/BackupModule.kt
@@ -5,7 +5,7 @@ import org.koin.dsl.module
 
 val backupModule = module {
     single { InputFactory() }
-    single { PackageService(androidContext().packageManager, get()) }
+    single { PackageService(androidContext(), get()) }
     single { ApkBackup(androidContext().packageManager, get(), get()) }
     single { KVBackup(get<BackupPlugin>().kvBackupPlugin, get(), get(), get(), get()) }
     single { FullBackup(get<BackupPlugin>().fullBackupPlugin, get(), get(), get()) }

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
@@ -16,6 +16,7 @@ import androidx.core.app.NotificationCompat.Builder
 import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
 import androidx.core.app.NotificationCompat.PRIORITY_HIGH
 import androidx.core.app.NotificationCompat.PRIORITY_LOW
+import com.stevesoltys.seedvault.BuildConfig.APPLICATION_ID
 import com.stevesoltys.seedvault.MAGIC_PACKAGE_MANAGER
 import com.stevesoltys.seedvault.R
 import com.stevesoltys.seedvault.restore.ACTION_RESTORE_ERROR_UNINSTALL
@@ -202,6 +203,15 @@ internal class BackupNotificationManager(private val context: Context) {
         expectedPmRecords = null
         expectedApps = null
         expectedAppTotals = null
+    }
+
+    fun hasActiveBackupNotifications(): Boolean {
+        nm.activeNotifications.forEach {
+            if (it.packageName == APPLICATION_ID &&
+                (it.id == NOTIFICATION_ID_OBSERVER || it.id == NOTIFICATION_ID_BACKGROUND)
+            ) return true
+        }
+        return false
     }
 
     fun onBackupError() {

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/BackupNotificationManager.kt
@@ -16,7 +16,6 @@ import androidx.core.app.NotificationCompat.Builder
 import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
 import androidx.core.app.NotificationCompat.PRIORITY_HIGH
 import androidx.core.app.NotificationCompat.PRIORITY_LOW
-import com.stevesoltys.seedvault.BuildConfig.APPLICATION_ID
 import com.stevesoltys.seedvault.MAGIC_PACKAGE_MANAGER
 import com.stevesoltys.seedvault.R
 import com.stevesoltys.seedvault.restore.ACTION_RESTORE_ERROR_UNINSTALL
@@ -207,7 +206,7 @@ internal class BackupNotificationManager(private val context: Context) {
 
     fun hasActiveBackupNotifications(): Boolean {
         nm.activeNotifications.forEach {
-            if (it.packageName == APPLICATION_ID &&
+            if (it.packageName == context.packageName &&
                 (it.id == NOTIFICATION_ID_OBSERVER || it.id == NOTIFICATION_ID_BACKGROUND)
             ) return true
         }

--- a/app/src/main/java/com/stevesoltys/seedvault/ui/notification/NotificationBackupObserver.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/ui/notification/NotificationBackupObserver.kt
@@ -19,8 +19,7 @@ private val TAG = NotificationBackupObserver::class.java.simpleName
 internal class NotificationBackupObserver(
     private val context: Context,
     private val expectedPackages: Int,
-    appTotals: ExpectedAppTotals,
-    private val userInitiated: Boolean
+    appTotals: ExpectedAppTotals
 ) : IBackupObserver.Stub(), KoinComponent {
 
     private val nm: BackupNotificationManager by inject()
@@ -31,7 +30,7 @@ internal class NotificationBackupObserver(
     init {
         // Inform the notification manager that a backup has started
         // and inform about the expected numbers, so it can compute a total.
-        nm.onBackupStarted(expectedPackages, appTotals, userInitiated)
+        nm.onBackupStarted(expectedPackages, appTotals)
     }
 
     /**
@@ -79,7 +78,7 @@ internal class NotificationBackupObserver(
         }
         val success = status == 0
         val numBackedUp = if (success) metadataManager.getPackagesNumBackedUp() else null
-        nm.onBackupFinished(success, numBackedUp, userInitiated)
+        nm.onBackupFinished(success, numBackedUp)
     }
 
     private fun showProgressNotification(packageName: String) {
@@ -93,7 +92,7 @@ internal class NotificationBackupObserver(
         currentPackage = packageName
         val app = getAppName(packageName)
         numPackages += 1
-        nm.onBackupUpdate(app, numPackages, userInitiated)
+        nm.onBackupUpdate(app, numPackages)
     }
 
     private fun getAppName(packageId: String): CharSequence = getAppName(context, packageId)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="notification_backup_result_complete">Backup complete</string>
     <string name="notification_backup_result_rejected">Not backed up</string>
     <string name="notification_backup_result_error">Backup failed</string>
+    <string name="notification_backup_already_running">Backup already in progress</string>
 
     <string name="notification_success_title">Backup finished</string>
     <string name="notification_success_text">%1$d of %2$d apps backed up. Tap to learn more.</string>


### PR DESCRIPTION
The system triggers backup jobs periodically or when a package is announcing that its data has changed. So far we were not showing notifications for those.

This MR shows a notification with an indeterminate progress bar as we don't have any information about how many packages will get backed up.