### PR TITLE
Optimize Key-Value Backup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,7 +134,10 @@ dependencies {
     def mockk_version = "1.10.0"
     testImplementation aospDeps  // anything less fails tests run with gradlew
     testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation('org.robolectric:robolectric:4.3.1') {
+        // https://github.com/robolectric/robolectric/issues/5245
+        exclude group: "com.google.auto.service", module: "auto-service"
+    }
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVBackup.kt
@@ -19,39 +19,21 @@ internal class DocumentsProviderKVBackup(
 ) : KVBackupPlugin {
 
     private var packageFile: DocumentFile? = null
+    private var packageChildren: List<DocumentFile>? = null
 
     override fun getQuota(): Long = DEFAULT_QUOTA_KEY_VALUE_BACKUP
 
     @Throws(IOException::class)
     override suspend fun hasDataForPackage(packageInfo: PackageInfo): Boolean {
-        val packageFile =
-            storage.currentKvBackupDir?.findFileBlocking(context, packageInfo.packageName)
-                ?: return false
-        return packageFile.listFilesBlocking(context).isNotEmpty()
-    }
-
-    @Throws(IOException::class)
-    override suspend fun ensureRecordStorageForPackage(packageInfo: PackageInfo) {
-        // remember package file for subsequent operations
-        packageFile =
+        // get the folder for the package (or create it) and all files in it
+        val dir =
             storage.getOrCreateKVBackupDir().createOrGetDirectory(context, packageInfo.packageName)
-    }
-
-    @Throws(IOException::class)
-    override suspend fun removeDataOfPackage(packageInfo: PackageInfo) {
-        // we cannot use the cached this.packageFile here,
-        // because this can be called before [ensureRecordStorageForPackage]
-        val packageFile =
-            storage.currentKvBackupDir?.findFileBlocking(context, packageInfo.packageName) ?: return
-        packageFile.delete()
-    }
-
-    @Throws(IOException::class)
-    override suspend fun deleteRecord(packageInfo: PackageInfo, key: String) {
-        val packageFile = this.packageFile ?: throw AssertionError()
-        packageFile.assertRightFile(packageInfo)
-        val keyFile = packageFile.findFileBlocking(context, key) ?: return
-        keyFile.delete()
+        val children = dir.listFilesBlocking(context)
+        // cache package file for subsequent operations
+        packageFile = dir
+        // also cache children as doing this for every record is super slow
+        packageChildren = children
+        return children.isNotEmpty()
     }
 
     @Throws(IOException::class)
@@ -59,6 +41,7 @@ internal class DocumentsProviderKVBackup(
         packageInfo: PackageInfo,
         key: String
     ): OutputStream {
+        // check maximum key lengths
         check(key.length <= MAX_KEY_LENGTH) {
             "Key $key for ${packageInfo.packageName} is too long: ${key.length} chars."
         }
@@ -68,10 +51,55 @@ internal class DocumentsProviderKVBackup(
                 "Key $key for ${packageInfo.packageName} is too long: ${key.length} chars."
             )
         }
-        val packageFile = this.packageFile ?: throw AssertionError()
+        // get dir and children from cache
+        val packageFile = this.packageFile
+            ?: throw AssertionError("No cached packageFile for ${packageInfo.packageName}")
         packageFile.assertRightFile(packageInfo)
-        val keyFile = packageFile.createOrGetFile(context, key)
+        val children = packageChildren
+            ?: throw AssertionError("No cached children for ${packageInfo.packageName}")
+
+        // get file for key from cache,
+        val keyFile = children.find { it.name == key } // try cache first
+            ?: packageFile.createFile(MIME_TYPE, key) // assume it doesn't exist, create it
+            ?: packageFile.createOrGetFile(context, key) // cache was stale, so try to find it
+        check(keyFile.name == key) { "Key file named ${keyFile.name}, but should be $key" }
         return storage.getOutputStream(keyFile)
+    }
+
+    @Throws(IOException::class)
+    override suspend fun deleteRecord(packageInfo: PackageInfo, key: String) {
+        val packageFile = this.packageFile
+            ?: throw AssertionError("No cached packageFile for ${packageInfo.packageName}")
+        packageFile.assertRightFile(packageInfo)
+
+        val children = packageChildren
+            ?: throw AssertionError("No cached children for ${packageInfo.packageName}")
+
+        // try to find file for given key and delete it if found
+        val keyFile = children.find { it.name == key } // try to find in cache
+            ?: packageFile.findFileBlocking(context, key) // fall-back to provider
+            ?: return // not found, nothing left to do
+        keyFile.delete()
+
+        // we don't update the children cache as deleted records
+        // are not expected to get re-added in the same backup pass
+    }
+
+    @Throws(IOException::class)
+    override suspend fun removeDataOfPackage(packageInfo: PackageInfo) {
+        val packageFile = this.packageFile
+            ?: throw AssertionError("No cached packageFile for ${packageInfo.packageName}")
+        packageFile.assertRightFile(packageInfo)
+        // We are not using the cached children here in case they are stale.
+        // This operation isn't frequent, so we don't need to heavily optimize it.
+        packageFile.deleteContents(context)
+        // clear children cache
+        packageChildren = ArrayList()
+    }
+
+    override fun packageFinished(packageInfo: PackageInfo) {
+        packageFile = null
+        packageChildren = null
     }
 
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderKVBackup.kt
@@ -47,7 +47,7 @@ internal class DocumentsProviderKVBackup(
         }
         if (key.length > MAX_KEY_LENGTH_NEXTCLOUD) {
             Log.e(
-                DocumentsProviderKVBackup::class.simpleName,
+                DocumentsProviderKVBackup::class.java.simpleName,
                 "Key $key for ${packageInfo.packageName} is too long: ${key.length} chars."
             )
         }

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsStorage.kt
@@ -32,7 +32,7 @@ const val DIRECTORY_FULL_BACKUP = "full"
 const val DIRECTORY_KEY_VALUE_BACKUP = "kv"
 const val FILE_BACKUP_METADATA = ".backup.metadata"
 const val FILE_NO_MEDIA = ".nomedia"
-private const val MIME_TYPE = "application/octet-stream"
+const val MIME_TYPE = "application/octet-stream"
 
 private val TAG = DocumentsStorage::class.java.simpleName
 

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackup.kt
@@ -91,14 +91,6 @@ internal class KVBackup(
             }
         }
 
-        // ensure there's a place to store K/V for the given package
-        try {
-            plugin.ensureRecordStorageForPackage(packageInfo)
-        } catch (e: IOException) {
-            Log.e(TAG, "Error ensuring storage for ${packageInfo.packageName}.", e)
-            return backupError(TRANSPORT_ERROR)
-        }
-
         // parse and store the K/V updates
         return storeRecords(packageInfo, data)
     }
@@ -221,6 +213,7 @@ internal class KVBackup(
 
     fun finishBackup(): Int {
         Log.i(TAG, "Finish K/V Backup of ${state!!.packageInfo.packageName}")
+        plugin.packageFinished(state!!.packageInfo)
         state = null
         return TRANSPORT_OK
     }
@@ -233,6 +226,7 @@ internal class KVBackup(
         "Resetting state because of K/V Backup error of ${state!!.packageInfo.packageName}".let {
             Log.i(TAG, it)
         }
+        plugin.packageFinished(state!!.packageInfo)
         state = null
         return result
     }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackupPlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/backup/KVBackupPlugin.kt
@@ -14,18 +14,13 @@ interface KVBackupPlugin {
     // TODO consider using a salted hash for the package name (and key) to not leak it to the storage server
     /**
      * Return true if there are records stored for the given package.
-     */
-    @Throws(IOException::class)
-    suspend fun hasDataForPackage(packageInfo: PackageInfo): Boolean
-
-    /**
-     * This marks the beginning of a backup operation.
+     * This is always called first per [PackageInfo], before subsequent methods.
      *
-     * Make sure that there is a place to store K/V pairs for the given package.
+     * Independent of the return value, the storage should now be prepared to store K/V pairs.
      * E.g. file-based plugins should a create a directory for the package, if none exists.
      */
     @Throws(IOException::class)
-    suspend fun ensureRecordStorageForPackage(packageInfo: PackageInfo)
+    suspend fun hasDataForPackage(packageInfo: PackageInfo): Boolean
 
     /**
      * Return an [OutputStream] for the given package and key
@@ -41,9 +36,16 @@ interface KVBackupPlugin {
     suspend fun deleteRecord(packageInfo: PackageInfo, key: String)
 
     /**
-     * Remove all data associated with the given package.
+     * Remove all data associated with the given package,
+     * but be prepared to receive new records afterwards with [getOutputStreamForRecord].
      */
     @Throws(IOException::class)
     suspend fun removeDataOfPackage(packageInfo: PackageInfo)
+
+    /**
+     * The package finished backup.
+     * This can be an opportunity to clear existing caches or to do other clean-up work.
+     */
+    fun packageFinished(packageInfo: PackageInfo)
 
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestorePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/KVRestorePlugin.kt
@@ -15,7 +15,8 @@ interface KVRestorePlugin {
     /**
      * Return all record keys for the given token and package.
      *
-     * Note: Implementations might expect that you call [hasDataForPackage] before.
+     * Note: Implementations usually expect that you call [hasDataForPackage]
+     *       with the same parameters before.
      *
      * For file-based plugins, this is usually a list of file names in the package directory.
      */

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/CoordinatorIntegrationTest.kt
@@ -126,7 +126,6 @@ internal class CoordinatorIntegrationTest : TransportTest() {
 
         // read one key/value record and write it to output stream
         coEvery { kvBackupPlugin.hasDataForPackage(packageInfo) } returns false
-        coEvery { kvBackupPlugin.ensureRecordStorageForPackage(packageInfo) } just Runs
         every { inputFactory.getBackupDataInput(fileDescriptor) } returns backupDataInput
         every { backupDataInput.readNextHeader() } returns true andThen true andThen false
         every { backupDataInput.key } returns key andThen key2
@@ -151,6 +150,7 @@ internal class CoordinatorIntegrationTest : TransportTest() {
                 key264
             )
         } returns bOutputStream2
+        every { kvBackupPlugin.packageFinished(packageInfo) } just Runs
         coEvery {
             apkBackup.backupApkIfNecessary(
                 packageInfo,
@@ -219,7 +219,6 @@ internal class CoordinatorIntegrationTest : TransportTest() {
 
         // read one key/value record and write it to output stream
         coEvery { kvBackupPlugin.hasDataForPackage(packageInfo) } returns false
-        coEvery { kvBackupPlugin.ensureRecordStorageForPackage(packageInfo) } just Runs
         every { inputFactory.getBackupDataInput(fileDescriptor) } returns backupDataInput
         every { backupDataInput.readNextHeader() } returns true andThen false
         every { backupDataInput.key } returns key
@@ -234,6 +233,7 @@ internal class CoordinatorIntegrationTest : TransportTest() {
                 key64
             )
         } returns bOutputStream
+        every { kvBackupPlugin.packageFinished(packageInfo) } just Runs
         coEvery { apkBackup.backupApkIfNecessary(packageInfo, UNKNOWN_ERROR, any()) } returns null
         coEvery { backupPlugin.getMetadataOutputStream() } returns metadataOutputStream
         every { metadataManager.onPackageBackedUp(packageInfo, metadataOutputStream) } just Runs


### PR DESCRIPTION
This PR caches the folder contents when making key-value backups or restores as it turned out getting files via SAF is super slow and can make operations with many records (e.g. `@pm@` and call log backup) very long.