### PR TITLE
Fix bug where we could not do two subsequent restores

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinator.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinator.kt
@@ -25,7 +25,7 @@ import com.stevesoltys.seedvault.ui.notification.BackupNotificationManager
 import libcore.io.IoUtils.closeQuietly
 import java.io.IOException
 
-private class RestoreCoordinatorState(
+private data class RestoreCoordinatorState(
     val token: Long,
     val packages: Iterator<PackageInfo>,
     /**
@@ -124,7 +124,7 @@ internal class RestoreCoordinator(
      * or [TRANSPORT_ERROR] (an error occurred, the restore should be aborted and rescheduled).
      */
     fun startRestore(token: Long, packages: Array<out PackageInfo>): Int {
-        check(state == null) { "Started new restore with existing state" }
+        check(state == null) { "Started new restore with existing state: $state" }
         Log.i(TAG, "Start restore with ${packages.map { info -> info.packageName }}")
 
         // If there's only one package to restore (Auto Restore feature), add it to the state
@@ -251,6 +251,7 @@ internal class RestoreCoordinator(
      * or will call [finishRestore] to shut down the restore operation.
      */
     fun abortFullRestore(): Int {
+        Log.d(TAG, "abortFullRestore")
         state?.currentPackage?.let { failedPackages.add(it) }
         return full.abortFullRestore()
     }
@@ -260,7 +261,9 @@ internal class RestoreCoordinator(
      * freeing any resources and connections used during the restore process.
      */
     fun finishRestore() {
+        Log.d(TAG, "finishRestore")
         if (full.hasState()) full.finishRestore()
+        state = null
     }
 
     /**

--- a/app/src/test/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinatorTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/transport/restore/RestoreCoordinatorTest.kt
@@ -109,6 +109,16 @@ internal class RestoreCoordinatorTest : TransportTest() {
     }
 
     @Test
+    fun `startRestore() can be be called again after restore finished`() {
+        assertEquals(TRANSPORT_OK, restore.startRestore(token, packageInfoArray))
+
+        every { full.hasState() } returns false
+        restore.finishRestore()
+
+        assertEquals(TRANSPORT_OK, restore.startRestore(token, packageInfoArray))
+    }
+
+    @Test
     fun `startRestore() optimized auto-restore with removed storage shows notification`() {
         every { settingsManager.getStorage() } returns storage
         every { storage.isUsb } returns true


### PR DESCRIPTION
This probably never showed in practice, but it can be triggered easily when testing with `adb shell bmgr restore`.