### PR TITLE
Re-install apps with APK splits if they are compatible

### DIFF
--- a/.idea/runConfigurations/Instrumentation_Tests.xml
+++ b/.idea/runConfigurations/Instrumentation_Tests.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Instrumentation Tests" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests">
-    <module name="app" />
+  <configuration default="false" name="Instrumentation Tests" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" singleton="true">
+    <module name="seedvault.app" />
     <option name="TESTING_TYPE" value="0" />
     <option name="METHOD_NAME" value="" />
     <option name="CLASS_NAME" value="" />
@@ -38,8 +38,11 @@
     </Native>
     <Profilers>
       <option name="ADVANCED_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_PROFILING_ENABLED" value="false" />
       <option name="STARTUP_CPU_PROFILING_ENABLED" value="false" />
       <option name="STARTUP_CPU_PROFILING_CONFIGURATION_NAME" value="Sample Java Methods" />
+      <option name="STARTUP_NATIVE_MEMORY_PROFILING_ENABLED" value="false" />
+      <option name="NATIVE_MEMORY_SAMPLE_RATE_BYTES" value="2048" />
     </Profilers>
     <method v="2">
       <option name="Android.Gradle.BeforeRunTask" enabled="true" />

--- a/.idea/runConfigurations/Unit_Tests.xml
+++ b/.idea/runConfigurations/Unit_Tests.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Unit Tests" type="AndroidJUnit" factoryName="Android JUnit">
-    <module name="app" />
+    <module name="seedvault.app" />
     <useClassPathOnly />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="ALTERNATIVE_JRE_PATH" value="/usr/lib/jvm/java-11" />

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
-script: ./gradlew check assemble ktlintCheck
+script: ./gradlew compileDebugAndroidTestSources check assemble ktlintCheck
 
 cache:
   directories:

--- a/app/src/androidTest/java/com/stevesoltys/seedvault/PluginTest.kt
+++ b/app/src/androidTest/java/com/stevesoltys/seedvault/PluginTest.kt
@@ -173,14 +173,18 @@ class PluginTest : KoinComponent {
         backupPlugin.getApkOutputStream(packageInfo, "").writeAndClose(apk1)
 
         // assert that read APK bytes match what was written
-        assertReadEquals(apk1, restorePlugin.getApkInputStream(token, packageInfo.packageName))
+        assertReadEquals(apk1, restorePlugin.getApkInputStream(token, packageInfo.packageName, ""))
 
         // write random bytes as another APK
+        val suffix2 = getRandomBase64(23)
         val apk2 = getRandomByteArray(23 * 1024 * 1024)
-        backupPlugin.getApkOutputStream(packageInfo2, "").writeAndClose(apk2)
+        backupPlugin.getApkOutputStream(packageInfo2, suffix2).writeAndClose(apk2)
 
         // assert that read APK bytes match what was written
-        assertReadEquals(apk2, restorePlugin.getApkInputStream(token, packageInfo2.packageName))
+        assertReadEquals(
+            apk2,
+            restorePlugin.getApkInputStream(token, packageInfo2.packageName, suffix2)
+        )
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,9 @@
     <!-- Getting info about installed packages via PackageManager is restricted since Android 11
          We need to know what is installed, with what signatures, etc. for APK backup,
          triggering manual backup and other tasks -->
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
 
     <application
         android:name=".App"

--- a/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderRestorePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/plugins/saf/DocumentsProviderRestorePlugin.kt
@@ -94,10 +94,14 @@ internal class DocumentsProviderRestorePlugin(
     }
 
     @Throws(IOException::class)
-    override suspend fun getApkInputStream(token: Long, packageName: String): InputStream {
+    override suspend fun getApkInputStream(
+        token: Long,
+        packageName: String,
+        suffix: String
+    ): InputStream {
         val setDir = storage.getSetDir(token) ?: throw IOException()
-        val file =
-            setDir.findFileBlocking(context, "$packageName.apk") ?: throw FileNotFoundException()
+        val file = setDir.findFileBlocking(context, "$packageName$suffix.apk")
+            ?: throw FileNotFoundException()
         return storage.getInputStream(file)
     }
 

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestorableBackup.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestorableBackup.kt
@@ -18,6 +18,9 @@ data class RestorableBackup(
     val time: Long
         get() = backupMetadata.time
 
+    val deviceName: String
+        get() = backupMetadata.deviceName
+
     val packageMetadataMap: PackageMetadataMap
         get() = backupMetadata.packageMetadataMap
 

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreProgressFragment.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreProgressFragment.kt
@@ -9,6 +9,7 @@ import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat.getColor
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -17,6 +18,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.VERTICAL
 import androidx.recyclerview.widget.RecyclerView
 import com.stevesoltys.seedvault.R
+import com.stevesoltys.seedvault.ui.AppBackupState.FAILED_NOT_INSTALLED
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class RestoreProgressFragment : Fragment() {
@@ -83,9 +85,23 @@ class RestoreProgressFragment : Fragment() {
                 backupNameView.setTextColor(getColor(requireContext(), R.color.red))
             } else {
                 backupNameView.text = getString(R.string.restore_finished_success)
+                onRestoreFinished()
             }
             activity?.window?.clearFlags(FLAG_KEEP_SCREEN_ON)
         })
+    }
+
+    private fun onRestoreFinished() {
+        // check if any restore failed, because the app is not installed
+        val failed = viewModel.restoreProgress.value?.any { it.state == FAILED_NOT_INSTALLED }
+        if (failed != true) return // nothing left to do if there's no failures due to not installed
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.restore_restoring_error_title)
+            .setMessage(R.string.restore_restoring_error_message)
+            .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
     }
 
     private fun stayScrolledAtTop(add: () -> Unit) {

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreViewModel.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/RestoreViewModel.kt
@@ -151,9 +151,9 @@ internal class RestoreViewModel(
         closeSession()
     }
 
-    private fun getInstallResult(restorableBackup: RestorableBackup): LiveData<InstallResult> {
+    private fun getInstallResult(backup: RestorableBackup): LiveData<InstallResult> {
         @Suppress("EXPERIMENTAL_API_USAGE")
-        return apkRestore.restore(restorableBackup.token, restorableBackup.packageMetadataMap)
+        return apkRestore.restore(backup.token, backup.deviceName, backup.packageMetadataMap)
             .onStart {
                 Log.d(TAG, "Start InstallResult Flow")
             }.catch { e ->

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkSplitCompatibilityChecker.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/ApkSplitCompatibilityChecker.kt
@@ -1,0 +1,118 @@
+package com.stevesoltys.seedvault.restore.install
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+
+private const val TAG = "SplitCompatChecker"
+
+private const val CONFIG_PREFIX = "config."
+private const val CONFIG_LENGTH = CONFIG_PREFIX.length
+
+private const val LDPI_VALUE = 120
+private const val MDPI_VALUE = 160
+private const val TVDPI_VALUE = 213
+private const val HDPI_VALUE = 240
+private const val XHDPI_VALUE = 320
+private const val XXHDPI_VALUE = 480
+private const val XXXHDPI_VALUE = 640
+
+class DeviceInfo(context: Context) {
+    val densityDpi: Int = context.resources.displayMetrics.densityDpi
+    val supportedABIs: List<String> = Build.SUPPORTED_ABIS.toList()
+}
+
+/**
+ * Tries to determine APK split compatibility with a device by examining the list of split names.
+ * This only looks on the supported ABIs and the screen density.
+ * Other config splits e.g. based on OpenGL or Vulkan version are also possible,
+ * but don't seem to be widely used, so we don't consider those for now.
+ */
+class ApkSplitCompatibilityChecker(private val deviceInfo: DeviceInfo) {
+
+    private val abiMap = mapOf(
+        "armeabi" to "armeabi",
+        "armeabi_v7a" to "armeabi-v7a",
+        "arm64_v8a" to "arm64-v8a",
+        "x86" to "x86",
+        "x86_64" to "x86_64",
+        "mips" to "mips",
+        "mips64" to "mips64"
+    )
+    private val densityMap = mapOf(
+        "ldpi" to LDPI_VALUE,
+        "mdpi" to MDPI_VALUE,
+        "tvdpi" to TVDPI_VALUE,
+        "hdpi" to HDPI_VALUE,
+        "xhdpi" to XHDPI_VALUE,
+        "xxhdpi" to XXHDPI_VALUE,
+        "xxxhdpi" to XXXHDPI_VALUE
+    )
+
+    /**
+     * Returns true if the list of splits can be considered compatible with the current device,
+     * and false otherwise.
+     */
+    fun isCompatible(splitNames: Collection<String>): Boolean = splitNames.all { splitName ->
+        // all individual splits need to be compatible (which can be hard to judge by name only)
+        isCompatible(splitName)
+    }
+
+    private fun isCompatible(splitName: String): Boolean {
+        val index = splitName.indexOf(CONFIG_PREFIX)
+        // If this is not a standardized config split, we just assume that it will work,
+        // as it is most likely a dynamic feature module.
+        if (index == -1) {
+            Log.v(TAG, "Not a config split '$splitName'. Assuming it is ok.")
+            return true
+        }
+
+        val name = splitName.substring(index + CONFIG_LENGTH)
+
+        // Check if this is a known ABI config
+        if (abiMap.containsKey(name)) {
+            // The ABI split must be supported by the current device
+            return isAbiCompatible(name)
+        }
+
+        // Check if this is a known screen density config
+        densityMap[name]?.let { splitDensity ->
+            // the split's density must not be much lower than the device's.
+            return isDensityCompatible(splitDensity)
+        }
+
+        // At this point we don't know what to make of that split,
+        // so let's just hope that it will work. It might just be a language.
+        Log.v(TAG, "Unhandled config split '$splitName'. Assuming it is ok.")
+        return true
+    }
+
+    private fun isAbiCompatible(name: String): Boolean {
+        return if (deviceInfo.supportedABIs.contains(abiMap[name])) {
+            Log.v(TAG, "Config split '$name' is supported ABI (${deviceInfo.supportedABIs})")
+            true
+        } else {
+            Log.w(TAG, "Config split '$name' is not supported ABI (${deviceInfo.supportedABIs})")
+            false
+        }
+    }
+
+    private fun isDensityCompatible(splitDensity: Int): Boolean {
+        @Suppress("MagicNumber")
+        val acceptableDiff = deviceInfo.densityDpi / 3
+        return if (deviceInfo.densityDpi - splitDensity > acceptableDiff) {
+            Log.w(
+                TAG,
+                "Config split density $splitDensity not compatible with ${deviceInfo.densityDpi}"
+            )
+            false
+        } else {
+            Log.v(
+                TAG,
+                "Config split density $splitDensity compatible with ${deviceInfo.densityDpi}"
+            )
+            true
+        }
+    }
+
+}

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/DeviceInfo.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/DeviceInfo.kt
@@ -1,0 +1,27 @@
+package com.stevesoltys.seedvault.restore.install
+
+import android.content.Context
+import android.os.Build
+import com.android.internal.app.LocalePicker
+import com.stevesoltys.seedvault.R
+
+class DeviceInfo(context: Context) {
+    val densityDpi: Int = context.resources.displayMetrics.densityDpi
+    val supportedABIs: List<String> = Build.SUPPORTED_ABIS.toList()
+    private val deviceName: String = "${Build.MANUFACTURER} ${Build.MODEL}"
+    private val languages = LocalePicker.getSupportedLocales(context)
+        .map { it.substringBefore('-') }
+        .toSet()
+    private val unknownSplitsOnlySameDevice =
+        context.resources.getBoolean(R.bool.re_install_unknown_splits_only_on_same_device)
+
+    fun areUnknownSplitsAllowed(deviceName: String): Boolean {
+        return !unknownSplitsOnlySameDevice || this.deviceName == deviceName
+    }
+
+    fun isSameDevice(deviceName: String): Boolean {
+        return this.deviceName == deviceName
+    }
+
+    fun isSupportedLanguage(name: String): Boolean = languages.contains(name)
+}

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
@@ -5,5 +5,6 @@ import org.koin.dsl.module
 
 val installModule = module {
     factory { ApkInstaller(androidContext()) }
-    factory { ApkRestore(androidContext(), get(), get()) }
+    factory { ApkSplitCompatibilityChecker(DeviceInfo(androidContext())) }
+    factory { ApkRestore(androidContext(), get(), get(), get()) }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/restore/install/InstallModule.kt
@@ -5,6 +5,7 @@ import org.koin.dsl.module
 
 val installModule = module {
     factory { ApkInstaller(androidContext()) }
-    factory { ApkSplitCompatibilityChecker(DeviceInfo(androidContext())) }
+    factory { DeviceInfo(androidContext()) }
+    factory { ApkSplitCompatibilityChecker(get()) }
     factory { ApkRestore(androidContext(), get(), get(), get()) }
 }

--- a/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestorePlugin.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/transport/restore/RestorePlugin.kt
@@ -34,6 +34,6 @@ interface RestorePlugin {
      * Returns an [InputStream] for the given token, for reading an APK that is to be restored.
      */
     @Throws(IOException::class)
-    suspend fun getApkInputStream(token: Long, packageName: String): InputStream
+    suspend fun getApkInputStream(token: Long, packageName: String, suffix: String): InputStream
 
 }

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -10,10 +10,26 @@
     -->
     <bool name="show_restore_in_settings">false</bool>
 
-    <!-- Add only storage that is also available when restoring from backup (e.g. initial device setup) -->
+    <!--
+    Add only storage here that is also available
+    when restoring from backup (e.g. initial device setup)
+    -->
     <string-array name="storage_authority_whitelist" tools:ignore="InconsistentArrays">
         <item>com.android.externalstorage.documents</item>
         <item>org.nextcloud.documents</item>
     </string-array>
+
+    <!--
+    Android App Bundles split up the app into several APKs.
+    We always back up all the available split APKs
+    and do a compatibility check when re-installing them.
+    If a backed up split is not compatible, the re-install will fail
+    and the user will be given the opportunity to install the app manually before data restore.
+    Unknown splits are treated as compatible as we haven't yet seen a case
+    where this would cause a problem such as an app crashing when starting it after re-install.
+    However, if you prefer to be on the safe side, you can set this to true,
+    to only install unknown splits if they come from the same device.
+    -->
+    <bool name="re_install_unknown_splits_only_on_same_device">false</bool>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,8 @@
     <string name="restore_installing_tap_to_install">Tap to install</string>
     <string name="restore_next">Next</string>
     <string name="restore_restoring">Restoring backup</string>
+    <string name="restore_restoring_error_title">Unable to restore some apps</string>
+    <string name="restore_restoring_error_message">You can re-install these apps manually and "Automatic restore" will attempt to restore their data (when enabled).</string>
     <string name="restore_magic_package">System package manager</string>
     <string name="restore_finished_success">Restore complete</string>
     <string name="restore_finished_error">An error occurred while restoring the backup.</string>

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkRestoreTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkRestoreTest.kt
@@ -46,9 +46,11 @@ internal class ApkRestoreTest : TransportTest() {
         every { packageManager } returns pm
     }
     private val restorePlugin: RestorePlugin = mockk()
+    private val splitCompatChecker: ApkSplitCompatibilityChecker = mockk()
     private val apkInstaller: ApkInstaller = mockk()
 
-    private val apkRestore: ApkRestore = ApkRestore(strictContext, restorePlugin, apkInstaller)
+    private val apkRestore: ApkRestore =
+        ApkRestore(strictContext, restorePlugin, splitCompatChecker, apkInstaller)
 
     private val icon: Drawable = mockk()
 
@@ -78,7 +80,7 @@ internal class ApkRestoreTest : TransportTest() {
         val packageMetadataMap: PackageMetadataMap = hashMapOf(packageName to packageMetadata)
 
         every { strictContext.cacheDir } returns File(tmpDir.toString())
-        coEvery { restorePlugin.getApkInputStream(token, packageName) } returns apkInputStream
+        coEvery { restorePlugin.getApkInputStream(token, packageName, "") } returns apkInputStream
 
         apkRestore.restore(token, packageMetadataMap).collectIndexed { index, value ->
             when (index) {
@@ -109,7 +111,7 @@ internal class ApkRestoreTest : TransportTest() {
         packageInfo.packageName = getRandomString()
 
         every { strictContext.cacheDir } returns File(tmpDir.toString())
-        coEvery { restorePlugin.getApkInputStream(token, packageName) } returns apkInputStream
+        coEvery { restorePlugin.getApkInputStream(token, packageName, "") } returns apkInputStream
         every { pm.getPackageArchiveInfo(any(), any()) } returns packageInfo
 
         apkRestore.restore(token, packageMetadataMap).collectIndexed { index, value ->
@@ -137,7 +139,7 @@ internal class ApkRestoreTest : TransportTest() {
     @Test
     fun `test apkInstaller throws exceptions`(@TempDir tmpDir: Path) = runBlocking {
         every { strictContext.cacheDir } returns File(tmpDir.toString())
-        coEvery { restorePlugin.getApkInputStream(token, packageName) } returns apkInputStream
+        coEvery { restorePlugin.getApkInputStream(token, packageName, "") } returns apkInputStream
         every { pm.getPackageArchiveInfo(any(), any()) } returns packageInfo
         every {
             pm.loadItemIcon(
@@ -194,7 +196,7 @@ internal class ApkRestoreTest : TransportTest() {
         }
 
         every { strictContext.cacheDir } returns File(tmpDir.toString())
-        coEvery { restorePlugin.getApkInputStream(token, packageName) } returns apkInputStream
+        coEvery { restorePlugin.getApkInputStream(token, packageName, "") } returns apkInputStream
         every { pm.getPackageArchiveInfo(any(), any()) } returns packageInfo
         every {
             pm.loadItemIcon(
@@ -247,7 +249,9 @@ internal class ApkRestoreTest : TransportTest() {
             val isSystemApp = Random.nextBoolean()
 
             every { strictContext.cacheDir } returns File(tmpDir.toString())
-            coEvery { restorePlugin.getApkInputStream(token, packageName) } returns apkInputStream
+            coEvery {
+                restorePlugin.getApkInputStream(token, packageName, "")
+            } returns apkInputStream
             every { pm.getPackageArchiveInfo(any(), any()) } returns packageInfo
             every {
                 pm.loadItemIcon(

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkSplitCompatibilityCheckerTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkSplitCompatibilityCheckerTest.kt
@@ -4,144 +4,175 @@ import com.stevesoltys.seedvault.getRandomString
 import com.stevesoltys.seedvault.transport.TransportTest
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class ApkSplitCompatibilityCheckerTest : TransportTest() {
 
     private val deviceInfo: DeviceInfo = mockk()
+    private val deviceName = getRandomString()
 
     private val checker = ApkSplitCompatibilityChecker(deviceInfo)
 
     @Test
-    fun `non-config splits always get accepted`() {
-        assertTrue(
-            checker.isCompatible(
-                listOf(
-                    getRandomString(),
-                    getRandomString(),
-                    getRandomString(),
-                    getRandomString(),
-                    getRandomString(),
-                    getRandomString()
-                )
-            )
+    fun `non-config splits always get accepted except when unknowns are not allowed`() {
+        val splits = listOf(
+            getRandomString(),
+            getRandomString(),
+            getRandomString(),
+            getRandomString(),
+            getRandomString(),
+            getRandomString()
         )
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns true andThen false
+        assertTrue(checker.isCompatible(deviceName, splits))
+        assertFalse(checker.isCompatible(deviceName, splits))
     }
 
     @Test
-    fun `non-config splits mixed with unknown config splits always get accepted`() {
-        assertTrue(
-            checker.isCompatible(
-                listOf(
-                    "config.de",
-                    "config.en",
-                    "config.gu",
-                    getRandomString(),
-                    getRandomString(),
-                    getRandomString()
-                )
-            )
+    fun `non-config splits mixed with language config splits get accepted iff allowed`() {
+        val splits = listOf(
+            "config.de",
+            "config.en",
+            "config.gu",
+            getRandomString(),
+            getRandomString(),
+            getRandomString()
         )
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns true andThen false
+        every { deviceInfo.isSupportedLanguage("de") } returns true
+        every { deviceInfo.isSupportedLanguage("en") } returns true
+        every { deviceInfo.isSupportedLanguage("gu") } returns true
+        assertTrue(checker.isCompatible(deviceName, splits))
+        assertFalse(checker.isCompatible(deviceName, splits))
+    }
+
+    @Test
+    fun `unknown config splits get rejected if from different device`() {
+        val unknownName = getRandomString()
+        val splits = listOf("config.$unknownName")
+        every { deviceInfo.isSupportedLanguage(unknownName) } returns false
+
+        // reject if on different device
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns Random.nextBoolean()
+        every { deviceInfo.isSameDevice(deviceName) } returns false
+        assertFalse(checker.isCompatible(deviceName, splits))
+
+        // accept if same device
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns Random.nextBoolean()
+        every { deviceInfo.isSameDevice(deviceName) } returns true
+        assertTrue(checker.isCompatible(deviceName, splits))
     }
 
     @Test
     fun `all supported ABIs get accepted, non-supported rejected`() {
+        val unknownAllowed = Random.nextBoolean()
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns unknownAllowed
         every { deviceInfo.supportedABIs } returns listOf("arm64-v8a", "armeabi-v7a", "armeabi")
 
-        assertTrue(checker.isCompatible(listOf("config.arm64_v8a")))
-        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.arm64_v8a")))
-        assertTrue(checker.isCompatible(listOf("config.armeabi_v7a")))
-        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.armeabi_v7a")))
-        assertTrue(checker.isCompatible(listOf("config.armeabi")))
-        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.armeabi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.arm64_v8a")))
+        assertEquals(
+            unknownAllowed,
+            checker.isCompatible(deviceName, listOf("${getRandomString()}.config.arm64_v8a"))
+        )
+        assertTrue(checker.isCompatible(deviceName, listOf("config.armeabi_v7a")))
+        assertEquals(
+            unknownAllowed,
+            checker.isCompatible(deviceName, listOf("${getRandomString()}.config.armeabi_v7a"))
+        )
+        assertTrue(checker.isCompatible(deviceName, listOf("config.armeabi")))
+        assertEquals(
+            unknownAllowed,
+            checker.isCompatible(deviceName, listOf("${getRandomString()}.config.armeabi"))
+        )
 
-        assertFalse(checker.isCompatible(listOf("config.x86")))
-        assertFalse(checker.isCompatible(listOf("config.x86_64")))
-        assertFalse(checker.isCompatible(listOf("config.mips")))
-        assertFalse(checker.isCompatible(listOf("config.mips64")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.x86")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.x86_64")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.mips")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.mips64")))
     }
 
     @Test
     fun `armeabi rejects arm64_v8a and armeabi-v7a`() {
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns true
         every { deviceInfo.supportedABIs } returns listOf("armeabi")
 
-        assertTrue(checker.isCompatible(listOf("config.armeabi")))
-        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.armeabi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.armeabi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("${getRandomString()}.config.armeabi")))
 
-        assertFalse(checker.isCompatible(listOf("config.arm64_v8a")))
-        assertFalse(checker.isCompatible(listOf("${getRandomString()}.config.arm64_v8a")))
-        assertFalse(checker.isCompatible(listOf("config.armeabi_v7a")))
-        assertFalse(checker.isCompatible(listOf("${getRandomString()}.config.armeabi_v7a")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.arm64_v8a")))
+        assertFalse(
+            checker.isCompatible(deviceName, listOf("${getRandomString()}.config.arm64_v8a"))
+        )
+        assertFalse(checker.isCompatible(deviceName, listOf("config.armeabi_v7a")))
+        assertFalse(
+            checker.isCompatible(deviceName, listOf("${getRandomString()}.config.armeabi_v7a"))
+        )
     }
 
     @Test
     fun `screen density is accepted when not too low`() {
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns Random.nextBoolean()
         every { deviceInfo.densityDpi } returns 440 // xxhdpi - Pixel 4
 
-        assertTrue(
-            checker.isCompatible(
-                listOf(
-                    "config.de",
-                    "config.xxxhdpi", // higher density is accepted
-                    getRandomString()
-                )
-            )
-        )
-        assertTrue(
-            checker.isCompatible(
-                listOf(
-                    "config.de",
-                    "config.xxhdpi", // same density is accepted
-                    getRandomString()
-                )
-            )
-        )
-        assertTrue(
-            checker.isCompatible(
-                listOf(
-                    "config.de",
-                    "config.xhdpi", // one lower density is accepted
-                    getRandomString()
-                )
-            )
-        )
-        assertFalse(
-            checker.isCompatible(
-                listOf(
-                    "config.de",
-                    "config.hdpi", // two lower density is not accepted
-                    getRandomString()
-                )
-            )
-        )
+        // higher density is accepted
+        assertTrue(checker.isCompatible(deviceName, listOf("config.xxxhdpi")))
+        // same density is accepted
+        assertTrue(checker.isCompatible(deviceName, listOf("config.xxhdpi")))
+        // one lower density is accepted
+        assertTrue(checker.isCompatible(deviceName, listOf("config.xhdpi")))
+        // too low density is not accepted
+        assertFalse(checker.isCompatible(deviceName, listOf("config.hdpi")))
         // even lower densities are also not accepted
-        assertFalse(checker.isCompatible(listOf("config.tvdpi")))
-        assertFalse(checker.isCompatible(listOf("config.mdpi")))
-        assertFalse(checker.isCompatible(listOf("config.ldpi")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.tvdpi")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.mdpi")))
+        assertFalse(checker.isCompatible(deviceName, listOf("config.ldpi")))
     }
 
     @Test
     fun `screen density accepts all higher densities`() {
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns Random.nextBoolean()
         every { deviceInfo.densityDpi } returns 120
 
-        assertTrue(checker.isCompatible(listOf("config.xxxhdpi")))
-        assertTrue(checker.isCompatible(listOf("config.xxhdpi")))
-        assertTrue(checker.isCompatible(listOf("config.xhdpi")))
-        assertTrue(checker.isCompatible(listOf("config.hdpi")))
-        assertTrue(checker.isCompatible(listOf("config.tvdpi")))
-        assertTrue(checker.isCompatible(listOf("config.mdpi")))
-        assertTrue(checker.isCompatible(listOf("config.ldpi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.xxxhdpi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.xxhdpi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.xhdpi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.hdpi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.tvdpi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.mdpi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.ldpi")))
+    }
+
+    @Test
+    fun `config splits in feature modules are considered unknown splits`() {
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns false
+
+        assertFalse(
+            checker.isCompatible(
+                deviceName,
+                listOf(
+                    "${getRandomString()}.config.xhdpi",
+                    "${getRandomString()}.config.arm64_v8a"
+                )
+            )
+        )
     }
 
     @Test
     fun `test mix of unknown and all known config splits`() {
+        val unknownAllowed = Random.nextBoolean()
+        every { deviceInfo.areUnknownSplitsAllowed(deviceName) } returns unknownAllowed
         every { deviceInfo.supportedABIs } returns listOf("armeabi-v7a", "armeabi")
         every { deviceInfo.densityDpi } returns 240
+        every { deviceInfo.isSupportedLanguage("de") } returns true
 
-        assertTrue(
+        assertEquals(
+            unknownAllowed,
             checker.isCompatible(
+                deviceName,
                 listOf(
                     "config.de",
                     "config.xhdpi",
@@ -153,6 +184,7 @@ class ApkSplitCompatibilityCheckerTest : TransportTest() {
         // same as above, but feature split with unsupported ABI config gets rejected
         assertFalse(
             checker.isCompatible(
+                deviceName,
                 listOf(
                     "config.de",
                     "config.xhdpi",
@@ -163,10 +195,14 @@ class ApkSplitCompatibilityCheckerTest : TransportTest() {
             )
         )
 
-        assertTrue(checker.isCompatible(listOf("config.xhdpi", "config.armeabi")))
-        assertTrue(checker.isCompatible(listOf("config.hdpi", "config.armeabi_v7a")))
-        assertFalse(checker.isCompatible(listOf("foo.config.ldpi", "config.armeabi_v7a")))
-        assertFalse(checker.isCompatible(listOf("foo.config.xxxhdpi", "bar.config.arm64_v8a")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.xhdpi", "config.armeabi")))
+        assertTrue(checker.isCompatible(deviceName, listOf("config.hdpi", "config.armeabi_v7a")))
+        assertFalse(
+            checker.isCompatible(deviceName, listOf("foo.config.ldpi", "config.armeabi_v7a"))
+        )
+        assertFalse(
+            checker.isCompatible(deviceName, listOf("foo.config.xxxhdpi", "bar.config.arm64_v8a"))
+        )
     }
 
 }

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkSplitCompatibilityCheckerTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/ApkSplitCompatibilityCheckerTest.kt
@@ -1,0 +1,172 @@
+package com.stevesoltys.seedvault.restore.install
+
+import com.stevesoltys.seedvault.getRandomString
+import com.stevesoltys.seedvault.transport.TransportTest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Test
+
+class ApkSplitCompatibilityCheckerTest : TransportTest() {
+
+    private val deviceInfo: DeviceInfo = mockk()
+
+    private val checker = ApkSplitCompatibilityChecker(deviceInfo)
+
+    @Test
+    fun `non-config splits always get accepted`() {
+        assertTrue(
+            checker.isCompatible(
+                listOf(
+                    getRandomString(),
+                    getRandomString(),
+                    getRandomString(),
+                    getRandomString(),
+                    getRandomString(),
+                    getRandomString()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `non-config splits mixed with unknown config splits always get accepted`() {
+        assertTrue(
+            checker.isCompatible(
+                listOf(
+                    "config.de",
+                    "config.en",
+                    "config.gu",
+                    getRandomString(),
+                    getRandomString(),
+                    getRandomString()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `all supported ABIs get accepted, non-supported rejected`() {
+        every { deviceInfo.supportedABIs } returns listOf("arm64-v8a", "armeabi-v7a", "armeabi")
+
+        assertTrue(checker.isCompatible(listOf("config.arm64_v8a")))
+        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.arm64_v8a")))
+        assertTrue(checker.isCompatible(listOf("config.armeabi_v7a")))
+        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.armeabi_v7a")))
+        assertTrue(checker.isCompatible(listOf("config.armeabi")))
+        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.armeabi")))
+
+        assertFalse(checker.isCompatible(listOf("config.x86")))
+        assertFalse(checker.isCompatible(listOf("config.x86_64")))
+        assertFalse(checker.isCompatible(listOf("config.mips")))
+        assertFalse(checker.isCompatible(listOf("config.mips64")))
+    }
+
+    @Test
+    fun `armeabi rejects arm64_v8a and armeabi-v7a`() {
+        every { deviceInfo.supportedABIs } returns listOf("armeabi")
+
+        assertTrue(checker.isCompatible(listOf("config.armeabi")))
+        assertTrue(checker.isCompatible(listOf("${getRandomString()}.config.armeabi")))
+
+        assertFalse(checker.isCompatible(listOf("config.arm64_v8a")))
+        assertFalse(checker.isCompatible(listOf("${getRandomString()}.config.arm64_v8a")))
+        assertFalse(checker.isCompatible(listOf("config.armeabi_v7a")))
+        assertFalse(checker.isCompatible(listOf("${getRandomString()}.config.armeabi_v7a")))
+    }
+
+    @Test
+    fun `screen density is accepted when not too low`() {
+        every { deviceInfo.densityDpi } returns 440 // xxhdpi - Pixel 4
+
+        assertTrue(
+            checker.isCompatible(
+                listOf(
+                    "config.de",
+                    "config.xxxhdpi", // higher density is accepted
+                    getRandomString()
+                )
+            )
+        )
+        assertTrue(
+            checker.isCompatible(
+                listOf(
+                    "config.de",
+                    "config.xxhdpi", // same density is accepted
+                    getRandomString()
+                )
+            )
+        )
+        assertTrue(
+            checker.isCompatible(
+                listOf(
+                    "config.de",
+                    "config.xhdpi", // one lower density is accepted
+                    getRandomString()
+                )
+            )
+        )
+        assertFalse(
+            checker.isCompatible(
+                listOf(
+                    "config.de",
+                    "config.hdpi", // two lower density is not accepted
+                    getRandomString()
+                )
+            )
+        )
+        // even lower densities are also not accepted
+        assertFalse(checker.isCompatible(listOf("config.tvdpi")))
+        assertFalse(checker.isCompatible(listOf("config.mdpi")))
+        assertFalse(checker.isCompatible(listOf("config.ldpi")))
+    }
+
+    @Test
+    fun `screen density accepts all higher densities`() {
+        every { deviceInfo.densityDpi } returns 120
+
+        assertTrue(checker.isCompatible(listOf("config.xxxhdpi")))
+        assertTrue(checker.isCompatible(listOf("config.xxhdpi")))
+        assertTrue(checker.isCompatible(listOf("config.xhdpi")))
+        assertTrue(checker.isCompatible(listOf("config.hdpi")))
+        assertTrue(checker.isCompatible(listOf("config.tvdpi")))
+        assertTrue(checker.isCompatible(listOf("config.mdpi")))
+        assertTrue(checker.isCompatible(listOf("config.ldpi")))
+    }
+
+    @Test
+    fun `test mix of unknown and all known config splits`() {
+        every { deviceInfo.supportedABIs } returns listOf("armeabi-v7a", "armeabi")
+        every { deviceInfo.densityDpi } returns 240
+
+        assertTrue(
+            checker.isCompatible(
+                listOf(
+                    "config.de",
+                    "config.xhdpi",
+                    "config.armeabi",
+                    getRandomString()
+                )
+            )
+        )
+        // same as above, but feature split with unsupported ABI config gets rejected
+        assertFalse(
+            checker.isCompatible(
+                listOf(
+                    "config.de",
+                    "config.xhdpi",
+                    "config.armeabi",
+                    "${getRandomString()}.config.arm64_v8a",
+                    getRandomString()
+                )
+            )
+        )
+
+        assertTrue(checker.isCompatible(listOf("config.xhdpi", "config.armeabi")))
+        assertTrue(checker.isCompatible(listOf("config.hdpi", "config.armeabi_v7a")))
+        assertFalse(checker.isCompatible(listOf("foo.config.ldpi", "config.armeabi_v7a")))
+        assertFalse(checker.isCompatible(listOf("foo.config.xxxhdpi", "bar.config.arm64_v8a")))
+    }
+
+}

--- a/app/src/test/java/com/stevesoltys/seedvault/restore/install/DeviceInfoTest.kt
+++ b/app/src/test/java/com/stevesoltys/seedvault/restore/install/DeviceInfoTest.kt
@@ -1,0 +1,86 @@
+package com.stevesoltys.seedvault.restore.install
+
+import android.content.Context
+import android.content.res.Resources
+import android.util.DisplayMetrics
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stevesoltys.seedvault.R
+import com.stevesoltys.seedvault.getRandomString
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.stopKoin
+import org.robolectric.annotation.Config
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29]) // robolectric does not support 30, yet
+internal class DeviceInfoTest {
+
+    @After
+    fun afterEachTest() {
+        stopKoin()
+    }
+
+    @Test
+    fun `test with mocked context`() {
+        val context: Context = mockk()
+        val resources: Resources = mockk()
+        val onlyOnSameDevice = Random.nextBoolean()
+
+        every { context.resources } returns resources
+        every { resources.displayMetrics } returns DisplayMetrics().apply {
+            this.densityDpi = 1337
+        }
+        every { resources.getStringArray(any()) } returns arrayOf("foo-123", "bar-rev")
+        every {
+            resources.getBoolean(R.bool.re_install_unknown_splits_only_on_same_device)
+        } returns onlyOnSameDevice
+
+        val deviceInfo = DeviceInfo(context)
+
+        // the ABI comes from robolectric
+        assertEquals(listOf("armeabi-v7a"), deviceInfo.supportedABIs)
+
+        // check that density is returned as expected
+        assertEquals(1337, deviceInfo.densityDpi)
+
+        // test languages results are as expected
+        assertTrue(deviceInfo.isSupportedLanguage("foo"))
+        assertTrue(deviceInfo.isSupportedLanguage("bar"))
+        assertFalse(deviceInfo.isSupportedLanguage("en"))
+        assertFalse(deviceInfo.isSupportedLanguage("de"))
+
+        // test areUnknownSplitsAllowed
+        val deviceName = "unknown robolectric"
+        if (onlyOnSameDevice) {
+            assertTrue(deviceInfo.areUnknownSplitsAllowed(deviceName))
+            assertFalse(deviceInfo.areUnknownSplitsAllowed("foo bar"))
+        } else {
+            assertTrue(deviceInfo.areUnknownSplitsAllowed(deviceName))
+            assertTrue(deviceInfo.areUnknownSplitsAllowed("foo bar"))
+        }
+    }
+
+    @Test
+    fun `test supported languages`() {
+        val deviceInfo = DeviceInfo(ApplicationProvider.getApplicationContext())
+
+        assertTrue(deviceInfo.isSupportedLanguage("en"))
+        assertTrue(deviceInfo.isSupportedLanguage("de"))
+        assertTrue(deviceInfo.isSupportedLanguage("gu"))
+        assertTrue(deviceInfo.isSupportedLanguage("pt"))
+
+        assertFalse(deviceInfo.isSupportedLanguage("foo"))
+        assertFalse(deviceInfo.isSupportedLanguage("bar"))
+        assertFalse(deviceInfo.isSupportedLanguage(getRandomString()))
+        assertFalse(deviceInfo.isSupportedLanguage(getRandomString()))
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     dependencies {
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 


### PR DESCRIPTION
This is the second part of #144 and builds upon this work to properly re-install apps even if they have APK splits. It introduces a compatibility checker which only looks at screen density and cpu architecture for now. This would work for all the splits I've seen so far. Unusual splits can be reported with https://gitlab.com/grote/app-bundle-reporter

More details as always can be found in the individual commit messages.

Fixes #91